### PR TITLE
Feat/8 kotest mockk 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+val kotestVersion = "5.5.4"
+
 plugins {
     id("org.springframework.boot") version "2.7.11" apply false
     id("io.spring.dependency-management") version "1.0.15.RELEASE" apply false
@@ -44,5 +46,11 @@ subprojects {
         implementation("org.jetbrains.kotlin:kotlin-reflect")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test")
+        testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+        testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+        testImplementation("io.kotest:kotest-framework-datatest:$kotestVersion")
+        testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
+        testImplementation("io.mockk:mockk:1.12.4")
+        testImplementation("com.ninja-squad:springmockk:3.1.2")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,7 @@
 rootProject.name = "Web-1-BE"
-include("web1-api")
-include("web1-domain")
-include("web1-infra")
+
+include(
+    "web1-api",
+    "web1-domain",
+    "web1-infra"
+)

--- a/web1-api/src/main/kotlin/com/yapp/web1be/test/TestService.kt
+++ b/web1-api/src/main/kotlin/com/yapp/web1be/test/TestService.kt
@@ -1,12 +1,11 @@
 package com.yapp.web1be.test
 
-import com.yapp.web1be.test.TestEntity
 import org.springframework.stereotype.Service
 
 @Service
 class TestService {
 
     fun test(): TestEntity {
-        return TestEntity(1, "test")
+        return TestEntity()
     }
 }

--- a/web1-api/src/test/kotlin/com/yapp/web1be/test/TestServiceTest.kt
+++ b/web1-api/src/test/kotlin/com/yapp/web1be/test/TestServiceTest.kt
@@ -1,0 +1,19 @@
+package com.yapp.web1be.test
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class TestServiceTest : StringSpec({
+    val testService:TestService = mockk()
+
+    "kotest 테스트 " {
+        // given
+        every { testService.test() } returns TestEntity()
+        val result = testService.test()
+
+        result.id shouldBe 1
+        result.name shouldBe "test"
+    }
+})

--- a/web1-domain/build.gradle.kts
+++ b/web1-domain/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 dependencies {
     runtimeOnly("com.h2database:h2")
 }
@@ -8,8 +10,7 @@ allOpen {
     annotation("javax.persistence.MappedSuperclass")
 }
 
-val jar: Jar by tasks
-val bootJar: org.springframework.boot.gradle.tasks.bundling.BootJar by tasks
-
-bootJar.enabled = false
-jar.enabled = true
+tasks {
+    withType<Jar> { enabled = true }
+    withType<BootJar> { enabled = false }
+}

--- a/web1-domain/src/main/kotlin/com/yapp/web1be/test/TestEntity.kt
+++ b/web1-domain/src/main/kotlin/com/yapp/web1be/test/TestEntity.kt
@@ -6,6 +6,6 @@ import javax.persistence.Id
 @Entity
 data class TestEntity(
     @Id
-    val id: Long,
-    val name: String
+    val id: Long = 1,
+    val name: String = "test"
 )

--- a/web1-infra/build.gradle.kts
+++ b/web1-infra/build.gradle.kts
@@ -1,8 +1,8 @@
 dependencies {
 
 }
-val jar: Jar by tasks
-val bootJar: org.springframework.boot.gradle.tasks.bundling.BootJar by tasks
 
-bootJar.enabled = false
-jar.enabled = true
+tasks {
+    withType<Jar> { enabled = true }
+    withType<org.springframework.boot.gradle.tasks.bundling.BootJar> { enabled = false }
+}


### PR DESCRIPTION
## 개요
- close #8 

## 작업사항
- kotest, mockk 추가

## 변경로직
- @cofls6581  build.gradle.kts 설정 다른분들 repo 참고해서 가독성이 좀 더 좋은것 같아 변경해보았는데 괜찮으실까요..?

## 기타
- 인텔리제이에서 kotest 실행시 plugin 설치 필요 - [kotest](https://plugins.jetbrains.com/plugin/14080-kotest)
- [kotest 테스트 스타일 참고](https://kotest.io/docs/framework/testing-styles.html)
- kotest-framework-datatest 의존성은 [Data Drive Testing](https://kotest.io/docs/framework/datatesting/data-driven-testing.html) 위해 추가
- [mockk](https://mockk.io/)은 코를린 mock 라이브러리
- ninja-squad:springmockk은 spring에서 mockk 사용을 위한 라이브러리