### PR TITLE
feat : BaseTimeEntity 생성

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/Application.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/Application.kt
@@ -2,8 +2,10 @@ package com.yapp.muckpot
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
+@EnableJpaAuditing
 class Application
 
 fun main(args: Array<String>) {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestResponse.kt
@@ -1,6 +1,7 @@
 package com.yapp.muckpot.test
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.yapp.muckpot.domains.test.entity.TestEntity
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import java.time.LocalDate
@@ -17,7 +18,7 @@ data class TestResponse(
 ) {
     companion object {
         fun of(testEntity: TestEntity): TestResponse {
-            return TestResponse(testEntity.id, testEntity.name, LocalDate.now())
+            return TestResponse(testEntity.id, testEntity.name, testEntity.createdAt.toLocalDate())
         }
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestService.kt
@@ -1,5 +1,8 @@
 package com.yapp.muckpot.test
 
+import com.yapp.muckpot.domains.test.entity.TestEntity
+import com.yapp.muckpot.domains.test.repository.TestQuerydslRepository
+import com.yapp.muckpot.domains.test.repository.TestRepository
 import org.springframework.stereotype.Service
 
 @Service

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/test/TestServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/test/TestServiceTest.kt
@@ -1,5 +1,6 @@
 package com.yapp.muckpot.test
 
+import com.yapp.muckpot.domains.test.entity.TestEntity
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/BaseTimeEntity.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/BaseTimeEntity.kt
@@ -1,0 +1,17 @@
+package com.yapp.muckpot.common
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.EntityListeners
+import javax.persistence.MappedSuperclass
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity(
+    @CreatedDate
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+    @LastModifiedDate
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/test/entity/TestEntity.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/test/entity/TestEntity.kt
@@ -1,5 +1,6 @@
-package com.yapp.muckpot.test
+package com.yapp.muckpot.domains.test.entity
 
+import com.yapp.muckpot.common.BaseTimeEntity
 import javax.persistence.Entity
 import javax.persistence.Id
 
@@ -8,4 +9,4 @@ data class TestEntity(
     @Id
     val id: Long = 1,
     val name: String = "test"
-)
+) : BaseTimeEntity()

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/test/repository/TestQuerydslRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/test/repository/TestQuerydslRepository.kt
@@ -1,7 +1,8 @@
-package com.yapp.muckpot.test
+package com.yapp.muckpot.domains.test.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.yapp.muckpot.test.QTestEntity.testEntity
+import com.yapp.muckpot.domains.test.entity.QTestEntity.testEntity
+import com.yapp.muckpot.domains.test.entity.TestEntity
 import org.springframework.stereotype.Repository
 
 @Repository

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/test/repository/TestRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/test/repository/TestRepository.kt
@@ -1,5 +1,6 @@
-package com.yapp.muckpot.test
+package com.yapp.muckpot.domains.test.repository
 
+import com.yapp.muckpot.domains.test.entity.TestEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 


### PR DESCRIPTION
## 개요
- close #20 

## 작업사항
- 도메인 패키징 구조 잡기 (test 예시 참조)
- BaseTimeEntity 생성
erd 설계 기준으로 컬럼명 맞췄습니다.
디폴트로 null 대신 현재 시각 사용했습니다.

## Ref
[JPA Auditing with kotlin](https://velog.io/@tkppp-dev/Spring-Data-JPA-Auditing-with-Kotlin)
