### PR TITLE
feat: .env 설정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,8 +1,11 @@
-name: muckpot api CI/CD script
+name: muckpot dev api CI/CD script
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "develop" ]
+
+env:
+  ACTIVE_PROFILE: "dev"
 
 permissions:
   contents: read
@@ -53,16 +56,15 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
-          username: ubuntu
+          username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_KEY }}
+          port: ${{ env.DEV_PORT }}
           script: |
+            sudo touch .env
+            echo "${{ secrets.ENV_VARS }}" | sudo tee .env > /dev/null
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/muckpot-api:${{ github.run_number }}
             docker stop $(docker ps -a -q)
-            docker run -d -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/muckpot-api:${{ github.run_number }}
+            docker run --restart=unless-stopped -d -p ${{ env.DEV_PORT }}:${{ env.DEV_PORT }} --env-file .env ${{ secrets.DOCKERHUB_USERNAME }}/muckpot-api:${{ github.run_number }}
             docker rm $(docker ps -a -q --filter "status=exited")
             docker image prune -a -f
-
-
-
-
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           context: ./muckpot-api
           push: true
+          args: --build-arg PROFILE=$ACTIVE_PROFILE
           tags: muckpot/muckpot-api:${{ github.run_number }}
 
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ out/
 
 ### dcoker mysql ###
 .mysqldata/
+
+### .env ###
+.env
+.env.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,21 @@ services:
     container_name: web1Redis
     image: "redis:alpine"
     ports:
-      - "6379:6379"
+      - ${REDIS_PORT}:${REDIS_PORT}
     environment:
       - TZ=Asia/Seoul
 
-  mysql:
-      image: mysql:8.0
-      container_name: web1Mysql
-      ports:
-        - 3306:3306
-      environment:
-        - MYSQL_DATABASE=testDB
-        - MYSQL_ROOT_PASSWORD=admin
-        - TZ=Asia/Seoul
-      command:
-        - --character-set-server=utf8mb4
-        - --collation-server=utf8mb4_unicode_ci
-      volumes:
-        - ./mysqldata:/var/lib/mysql
+#  mysql: mariadb로 변경 필요
+#      image: mysql:8.0
+#      container_name: web1Mysql
+#      ports:
+#        - 3306:3306
+#      environment:
+#        - MYSQL_DATABASE=testDB
+#        - MYSQL_ROOT_PASSWORD=admin
+#        - TZ=Asia/Seoul
+#      command:
+#        - --character-set-server=utf8mb4
+#        - --collation-server=utf8mb4_unicode_ci
+#      volumes:
+#        - ./mysqldata:/var/lib/mysql

--- a/muckpot-api/Dockerfile
+++ b/muckpot-api/Dockerfile
@@ -6,7 +6,7 @@ ARG JAR_FILE=build/libs/*.jar
 
 COPY ${JAR_FILE} app.jar
 
-ARG PROFILE=local
+ARG PROFILE=dev
 ENV PROFILE=${PROFILE}
 
 ENTRYPOINT ["java","-Dspring.profiles.active=${PROFILE}","-jar","/app.jar"]

--- a/muckpot-domain/src/main/resources/application-dev.yml
+++ b/muckpot-domain/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    driver-class-name:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+
+## 추후 RDS로 연동


### PR DESCRIPTION
## 개요
- close #23 

## 작업사항
서브모듈 방식을 활용한 민감정보 관리는 보안상 취약한 단점이 있어 시스템 환경 변수를 사용하는 방식으로 작업했습니다.
- .env 설정 후 기존 민감정보 값 매핑
- .env .gitignore에 추가
- dev 환경 cicd 스크립트에 .env 동기화 로직 추가
- github secrets에 ENV_VARS(.env 값) 추가
- keybase에 .env 파일 업로드 완료
+ 추가 작업
- 기존 cicd 스크립트를 dev환경 cicd 스크립트로 더 구체적으로 명시하여 수정했습니다.
- docker run 명령어에 --restart=unless-stopped 추가했습니다. (컨테이너 비정상 종료 시 자동 재시작 옵션) 

## 변경로직
- .env 인텔리제이에서 설정법
run→edit configurations→enable env file→shift+command+.(파인더 숨긴 파일 보기 명령어)→env파일 추가→apply
- .env 파일 변경이 생길 시
keybase와 github ENV_VARS 최신화 후 변경 사항 생겼다고 pr에 언급 부탁드립니다!
ec2 내 .env는 cicd 스크립트에서 자동으로 덮어씌워지도록 로직 추가해둬서 따로 신경 안쓰셔도됩니당ㅎㅎ