### PR TITLE
Feat/27 test fix

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestController.kt
@@ -1,5 +1,7 @@
 package com.yapp.muckpot.test
 
+import com.yapp.muckpot.common.ResponseDto
+import com.yapp.muckpot.common.ResponseEntityUtil
 import com.yapp.muckpot.swagger.TEST_SAMPLE
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
@@ -36,8 +38,8 @@ class TestController(private val testService: TestService) {
             )
         ]
     )
-    fun getTest(): TestResponse {
-        return testService.test()
+    fun getTest(): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.ok(testService.test())
     }
 
     @PostMapping("/v1/test")
@@ -45,7 +47,7 @@ class TestController(private val testService: TestService) {
     fun postTest(
         @RequestBody @Valid
         request: TestRequest
-    ): ResponseEntity<String> {
-        return ResponseEntity.ok("${request.name}(${request.age})")
+    ): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.created(testService.save(request))
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestController.kt
@@ -1,7 +1,5 @@
 package com.yapp.muckpot.test
 
-import com.yapp.muckpot.common.ResponseDto
-import com.yapp.muckpot.common.ResponseEntityUtil
 import com.yapp.muckpot.swagger.TEST_SAMPLE
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
@@ -38,8 +36,8 @@ class TestController(private val testService: TestService) {
             )
         ]
     )
-    fun getTest(): ResponseEntity<ResponseDto> {
-        return ResponseEntityUtil.ok(testService.test())
+    fun getTest(): TestResponse {
+        return testService.test()
     }
 
     @PostMapping("/v1/test")
@@ -47,7 +45,7 @@ class TestController(private val testService: TestService) {
     fun postTest(
         @RequestBody @Valid
         request: TestRequest
-    ): ResponseEntity<ResponseDto> {
-        return ResponseEntityUtil.created(testService.save())
+    ): ResponseEntity<String> {
+        return ResponseEntity.ok("${request.name}(${request.age})")
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestResponse.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 @ApiModel(value = "테스트 Response")
 data class TestResponse(
     @field:ApiModelProperty(notes = "테스트Dto 아이디", example = "test")
-    var id: Long? = 1,
+    var id: Long? = null,
     @field:ApiModelProperty(notes = "테스트Dto 이름", example = "test")
     var name: String = "test",
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMdd")

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestService.kt
@@ -12,7 +12,11 @@ class TestService(
 ) {
 
     fun test(): TestResponse {
-        testRepository.save(TestEntity(1, "querydsl"))
+        testRepository.save(TestEntity(null, "querydsl"))
         return TestResponse.of(querydslRepository.getTestByName("querydsl") ?: TestEntity())
+    }
+
+    fun save(request: TestRequest): Long? {
+        return testRepository.save(TestEntity(null, request.name ?: "test")).id
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestService.kt
@@ -4,7 +4,6 @@ import com.yapp.muckpot.domains.test.entity.TestEntity
 import com.yapp.muckpot.domains.test.repository.TestQuerydslRepository
 import com.yapp.muckpot.domains.test.repository.TestRepository
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class TestService(
@@ -15,9 +14,5 @@ class TestService(
     fun test(): TestResponse {
         testRepository.save(TestEntity(1, "querydsl"))
         return TestResponse.of(querydslRepository.getTestByName("querydsl") ?: TestEntity())
-    }
-
-    fun save(): Long? {
-        return testRepository.save(TestEntity(null, UUID.randomUUID().toString())).id
     }
 }


### PR DESCRIPTION
- DB 저장 테스트 가능하도록 수정

## 개요
- close #27 

## 작업사항
- DB 저장 테스트 가능하도록 수정

## 변경로직
- 한글 저장 시 ``` (conn=4643) Incorrect string value:  ``` 오류가 발생해서 테이블 마다 char set 설정 쿼리로 추가하였습니다..
```
alter table board convert to char set utf8;
```