### PR TITLE
feat: logback 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ subprojects {
         implementation("org.springframework.boot:spring-boot-starter-data-jpa")
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
+        implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestController.kt
@@ -10,6 +10,7 @@ import io.swagger.annotations.ApiResponse
 import io.swagger.annotations.ApiResponses
 import io.swagger.annotations.Example
 import io.swagger.annotations.ExampleProperty
+import mu.KLogging
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,6 +27,8 @@ class TestController(
     private val testService: TestService,
     private val redisService: RedisService
 ) {
+    private val log = KLogging().logger
+
     @GetMapping("/v1/test")
     @ApiOperation(value = "Get 테스트")
     @ApiResponses(
@@ -43,6 +46,9 @@ class TestController(
         ]
     )
     fun getTest(): ResponseEntity<ResponseDto> {
+        log.info { "info" }
+        log.warn { "warn" }
+        log.error { "error" }
         return ResponseEntityUtil.ok(testService.test())
     }
 

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/test/TestService.kt
@@ -12,7 +12,9 @@ class TestService(
 ) {
 
     fun test(): TestResponse {
-        testRepository.save(TestEntity(null, "querydsl"))
+        val testEntity = TestEntity(null, "querydsl")
+        testRepository.save(testEntity)
+        testEntity.loggingTest()
         return TestResponse.of(querydslRepository.getTestByName("querydsl") ?: TestEntity())
     }
 

--- a/muckpot-api/src/main/resources/application.yml
+++ b/muckpot-api/src/main/resources/application.yml
@@ -10,3 +10,6 @@ spring:
 
   jpa:
     open-in-view: false
+
+logging:
+  config: classpath:logback-${spring.config.activate.on-profile}.xml

--- a/muckpot-api/src/main/resources/logback-dev.xml
+++ b/muckpot-api/src/main/resources/logback-dev.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <springProperty name="INFO_LOG_PATH" source="./logs/info"/>
+    <springProperty name="WARN_LOG_PATH" source="./logs/warn"/>
+    <springProperty name="ERROR_LOG_PATH" source="./logs/error"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [File:%F] [Func:%M] [Line:%L] [Message:%m] %n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${INFO_LOG_PATH}</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/info/%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>15</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [File:%F] [Func:%M] [Line:%L] [Message:%m] %n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${WARN_LOG_PATH}</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/warn/%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>15</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [File:%F] [Func:%M] [Line:%L] [Message:%m] %n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${ERROR_LOG_PATH}</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/error/%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>15</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [File:%F] [Func:%M] [Line:%L] [Message:%m] %n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/muckpot-api/src/main/resources/logback-local.xml
+++ b/muckpot-api/src/main/resources/logback-local.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%highlight(%-5level) %date [%thread] %cyan([%C{0} :: %M :: %L]) - %msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/test/entity/TestEntity.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/test/entity/TestEntity.kt
@@ -1,6 +1,7 @@
 package com.yapp.muckpot.domains.test.entity
 
 import com.yapp.muckpot.common.BaseTimeEntity
+import mu.KLogging
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
@@ -10,6 +11,13 @@ import javax.persistence.Id
 data class TestEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long ? = 1,
+    val id: Long? = 1,
     val name: String = "test"
-) : BaseTimeEntity()
+) : BaseTimeEntity() {
+    fun loggingTest() {
+        val log = KLogging().logger
+        log.info { "info" }
+        log.warn { "warn" }
+        log.error { "error" }
+    }
+}


### PR DESCRIPTION
## 개요
- close #32 

## 작업사항
- logback 설정 추가
- logback 테스트를 위한 로깅 추가
- 보내주신 파일 참고하여 만들었습니다. 👍

## 로깅 정책
- local에서는 파일을 만들 필요가 없을것 같아서 제외시켰습니다.
- log, info, warn 레벨 별로 로그파일을 분리하여 작성합니다.
- maxFileSize: 로그 파일이 10MB를 초과하면 롤링이 발생합니다.
- maxHistory: 보관할 이전 로그 파일의 최대 개수, 최대 15개의 이전 로그 파일을 유지합니다.