### PR TITLE
feat: 35 login 기능 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
+    - name: Docker Container Run
+      run: docker-compose up -d
+
     - name: Gradle Clean & Build
       run: ./gradlew clean build
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,6 +23,9 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+      - name: Docker Container Run
+        run: docker-compose up -d
+
       - name: Gradle Clean & Build
         run: ./gradlew clean build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: web1Redis
     image: "redis:alpine"
     ports:
-      - ${REDIS_PORT}:${REDIS_PORT}
+      - 6379:6379
     environment:
       - TZ=Asia/Seoul
 

--- a/muckpot-api/build.gradle.kts
+++ b/muckpot-api/build.gradle.kts
@@ -5,4 +5,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("io.springfox:springfox-boot-starter:3.0.0")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("com.auth0:java-jwt:4.2.1")
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtConstant.kt
@@ -1,0 +1,3 @@
+package com.yapp.muckpot.common
+
+const val LOGIN_URL = "/api/v1/users/login"

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtCookieUtil.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtCookieUtil.kt
@@ -1,0 +1,56 @@
+package com.yapp.muckpot.common
+
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import org.springframework.web.util.WebUtils
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Jwt Cookie 접근 위한 공통 클래스
+ */
+object JwtCookieUtil {
+    private const val ACCESS_TOKEN = "accessToken"
+    private const val REFRESH_TOKEN = "refreshToken"
+
+    private val currentRequest: HttpServletRequest
+        get() = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
+    private val currentResponse: HttpServletResponse
+        get() = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).response
+            ?: throw IllegalStateException("HttpServletResponse 가 존재하지 않습니다.")
+
+    /**
+     * 현재 Request 에서 AccessToken 을 추출
+     *
+     * @exception IllegalArgumentException 쿠키 값이 없는 경우
+     */
+    fun getAccessToken(): String {
+        val cookie = WebUtils.getCookie(currentRequest, ACCESS_TOKEN)
+        return cookie?.value ?: throw IllegalArgumentException("로그인 정보가 존재하지 않습니다.")
+    }
+
+    /**
+     * 현재 응답에 ACCESS_TOKEN 쿠키 추가.
+     */
+    fun addAccessTokenCookie(accessToken: String) {
+        currentResponse.addCookie(
+            Cookie(ACCESS_TOKEN, accessToken).apply {
+                path = "/"
+                isHttpOnly = true
+            }
+        )
+    }
+
+    /**
+     * 현재 응답에 REFRESH_TOKEN 쿠키 추가.
+     */
+    fun addRefreshTokenCookie(jwtToken: String) {
+        currentResponse.addCookie(
+            Cookie(REFRESH_TOKEN, jwtToken).apply {
+                path = "/"
+                isHttpOnly = true
+            }
+        )
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/ResponseWriter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/ResponseWriter.kt
@@ -1,0 +1,32 @@
+package com.yapp.muckpot.common
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * filter 예외 발생 시 응답에 직접 데이터를 넣어주기 위한 클래스
+ */
+object ResponseWriter {
+    private val objectMapper = ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+
+    /**
+     * Response에 직접 예외 응답 작성
+     */
+    fun writeResponse(response: HttpServletResponse, httpStatus: HttpStatus, message: String) {
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.status = httpStatus.value()
+        response.outputStream.use { os ->
+            objectMapper.writeValue(
+                os,
+                ResponseDto(
+                    status = httpStatus.value(),
+                    message
+                )
+            )
+            os.flush()
+        }
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/security/AuthenticationUser.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/security/AuthenticationUser.kt
@@ -1,0 +1,25 @@
+package com.yapp.muckpot.common.security
+
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+import java.time.LocalDateTime
+
+data class AuthenticationUser(
+    val userId: Long,
+    val credential: Any,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val authorities: List<GrantedAuthority>
+) : AbstractAuthenticationToken(authorities) {
+    constructor(userId: Long, credential: Any, isAuthentication: Boolean, authorities: List<GrantedAuthority>) :
+        this(userId = userId, credential = credential, authorities = authorities) {
+        isAuthenticated = isAuthentication
+    }
+
+    override fun getPrincipal(): Any {
+        return userId
+    }
+
+    override fun getCredentials(): Any {
+        return credential
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/security/CustomAuthenticationEntryPoint.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/security/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,26 @@
+package com.yapp.muckpot.common.security
+
+import com.yapp.muckpot.common.ResponseWriter
+import mu.KLogging
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
+    private val log = KLogging().logger
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        log.debug(authException) { NO_AUTH }
+        ResponseWriter.writeResponse(response, HttpStatus.FORBIDDEN, NO_AUTH)
+    }
+
+    companion object {
+        private const val NO_AUTH = "권한이 존재하지 않습니다."
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.yapp.muckpot.common.LOGIN_URL
 import com.yapp.muckpot.common.security.CustomAuthenticationEntryPoint
 import com.yapp.muckpot.domains.user.service.JwtService
 import com.yapp.muckpot.filter.JwtAuthorizationFilter
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -20,9 +21,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 class SecurityConfig(
-    private val jwtService: JwtService
+    private val jwtService: JwtService,
+    @Value("\${api.option.permit-all}")
+    private val permitAll: Boolean
 ) {
-
     @Bean
     @Throws(Exception::class)
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
@@ -33,8 +35,13 @@ class SecurityConfig(
                     .permitAll()
                     .antMatchers(HttpMethod.GET, "/api/**", "/swagger-ui/**")
                     .permitAll()
-                    .antMatchers("/api/**")
-                    .hasRole("USER")
+                    .antMatchers("/api/**").apply {
+                        if (permitAll) {
+                            permitAll()
+                        } else {
+                            hasRole("USER")
+                        }
+                    }
             }
             .cors { cors ->
                 cors.configurationSource(corsConfigurationSource())

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
@@ -1,0 +1,79 @@
+package com.yapp.muckpot.config
+
+import com.yapp.muckpot.common.LOGIN_URL
+import com.yapp.muckpot.common.security.CustomAuthenticationEntryPoint
+import com.yapp.muckpot.domains.user.service.JwtService
+import com.yapp.muckpot.filter.JwtAuthorizationFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.builders.WebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+class SecurityConfig(
+    private val jwtService: JwtService
+) {
+
+    @Bean
+    @Throws(Exception::class)
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .authorizeHttpRequests { authz ->
+                authz
+                    .antMatchers(LOGIN_URL)
+                    .permitAll()
+                    .antMatchers(HttpMethod.GET, "/api/**", "/swagger-ui/**")
+                    .permitAll()
+                    .antMatchers("/api/**")
+                    .hasRole("USER")
+            }
+            .cors { cors ->
+                cors.configurationSource(corsConfigurationSource())
+            }
+            .addFilterBefore(JwtAuthorizationFilter(jwtService), BasicAuthenticationFilter::class.java)
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .csrf().disable()
+            .formLogin().disable()
+            .httpBasic().disable()
+            .exceptionHandling()
+            .authenticationEntryPoint(CustomAuthenticationEntryPoint())
+
+        return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): UrlBasedCorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        val source = UrlBasedCorsConfigurationSource()
+
+        configuration.allowedOrigins = listOf("*")
+        configuration.allowedMethods = listOf("*")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
+
+    @Bean
+    fun webSecurityCustomizer(): WebSecurityCustomizer {
+        return WebSecurityCustomizer { web: WebSecurity ->
+            web.ignoring()
+                .antMatchers("/swagger-ui/**")
+        }
+    }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/UserController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/UserController.kt
@@ -1,0 +1,51 @@
+package com.yapp.muckpot.domains.user.controller
+
+import com.yapp.muckpot.common.ResponseDto
+import com.yapp.muckpot.common.ResponseEntityUtil
+import com.yapp.muckpot.domains.user.controller.dto.LoginRequest
+import com.yapp.muckpot.domains.user.service.UserService
+import com.yapp.muckpot.swagger.LOGIN_RESPONSE
+import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiResponse
+import io.swagger.annotations.ApiResponses
+import io.swagger.annotations.Example
+import io.swagger.annotations.ExampleProperty
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
+
+@RestController
+@Api(tags = ["유저 api"], description = "유저 API")
+@RequestMapping("/api")
+class UserController(
+    private val userService: UserService
+) {
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 200,
+                examples = Example(
+                    ExampleProperty(
+                        value = LOGIN_RESPONSE,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "로그인")
+    @PostMapping("/v1/users/login")
+    fun login(
+        @RequestBody @Valid
+        request: LoginRequest
+    ): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.ok(userService.login(request))
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/LoginRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/LoginRequest.kt
@@ -1,0 +1,21 @@
+package com.yapp.muckpot.domains.user.controller.dto
+
+import com.yapp.muckpot.common.enums.YesNo
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiModelProperty
+import javax.validation.constraints.Pattern
+
+@ApiModel(value = "로그인 요청")
+data class LoginRequest(
+    @field:ApiModelProperty(notes = "이메일", required = true, example = "user@samsung.com")
+    @field:Pattern(regexp = "^[A-Za-z0-9._%+-]+@samsung\\.com$", message = "현재 버전은 삼성전자 사우만 이용 가능합니다.")
+    val email: String,
+    @field:ApiModelProperty(notes = "비밀번호", required = true, example = "abcd1234")
+    @field:Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$",
+        message = "비밀 번호는 영문과 숫자를 포함하여 8 ~ 20자로 입력해 주세요."
+    )
+    val password: String,
+    @field:ApiModelProperty(notes = "로그인 유지하기", required = true, example = "Y")
+    val keep: YesNo = YesNo.Y
+)

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/UserResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/dto/UserResponse.kt
@@ -1,0 +1,14 @@
+package com.yapp.muckpot.domains.user.controller.dto
+
+import com.yapp.muckpot.domains.user.entity.MuckPotUser
+
+data class UserResponse(
+    val userId: Long,
+    val nickName: String = ""
+) {
+    companion object {
+        fun of(user: MuckPotUser): UserResponse {
+            return UserResponse(user.id ?: 0, user.nickName)
+        }
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
@@ -1,0 +1,73 @@
+package com.yapp.muckpot.domains.user.service
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.JWTVerifier
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.DecodedJWT
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yapp.muckpot.common.JwtCookieUtil
+import com.yapp.muckpot.common.enums.YesNo
+import com.yapp.muckpot.domains.user.controller.dto.UserResponse
+import mu.KLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class JwtService(
+    private val objectMapper: ObjectMapper,
+    @Value("\${jwt.issuer}")
+    private val issuer: String,
+    @Value("\${jwt.secret-key}")
+    private val secretKey: String
+) {
+    private val log = KLogging().logger
+    private val algorithm: Algorithm by lazy { Algorithm.HMAC512(secretKey) }
+    private val jwtVerifier: JWTVerifier by lazy { JWT.require(algorithm).build() }
+
+    fun generateAccessToken(response: UserResponse, keep: YesNo): String {
+        val jwtBuilder = JWT.create()
+            .withIssuer(issuer)
+            .withClaim(USER_CLAIM, objectMapper.writeValueAsString(response))
+        if (keep == YesNo.N) {
+            jwtBuilder.withExpiresAt(Date(Date().time + ACCESS_EXPIRE_TIME))
+        }
+        return jwtBuilder.sign(algorithm)
+    }
+
+    fun generateRefreshToken(email: String, keep: YesNo): String {
+        val jwtBuilder = JWT.create()
+            .withIssuer(issuer)
+            .withClaim(USER_EMAIL_CLAIM, email)
+        if (keep == YesNo.N) {
+            jwtBuilder.withExpiresAt(Date(Date().time + REFRESH_EXPIRE_TIME))
+        }
+        return jwtBuilder.sign(algorithm)
+    }
+
+    /**
+     * 현재 HttpServletRequest의 AccessToken을 찾아 유저 정보 반환
+     *
+     * @return UserResponse? 유저 정보가 없는 경우 null 반환
+     */
+    fun getCurrentUserClaim(): UserResponse? {
+        return try {
+            val decodedJwt = verify(JwtCookieUtil.getAccessToken())
+            objectMapper.readValue(decodedJwt.getClaim(USER_CLAIM).asString(), UserResponse::class.java)
+        } catch (exception: Exception) {
+            log.info(exception) { "로그인 유저 정보를 찾을 수 없습니다." }
+            null
+        }
+    }
+
+    private fun verify(token: String): DecodedJWT {
+        return jwtVerifier.verify(token)
+    }
+
+    companion object {
+        private const val USER_CLAIM = "user"
+        private const val USER_EMAIL_CLAIM = "email"
+        private const val ACCESS_EXPIRE_TIME = 3600000 // 1시간
+        private const val REFRESH_EXPIRE_TIME = 604800000 // 일주일
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
@@ -55,7 +55,8 @@ class JwtService(
             val decodedJwt = verify(JwtCookieUtil.getAccessToken())
             objectMapper.readValue(decodedJwt.getClaim(USER_CLAIM).asString(), UserResponse::class.java)
         } catch (exception: Exception) {
-            log.info(exception) { "로그인 유저 정보를 찾을 수 없습니다." }
+            log.debug(exception) { "" }
+            log.info { "로그인 유저 정보를 찾을 수 없습니다." }
             null
         }
     }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/UserService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/UserService.kt
@@ -1,0 +1,38 @@
+package com.yapp.muckpot.domains.user.service
+
+import com.yapp.muckpot.common.JwtCookieUtil
+import com.yapp.muckpot.domains.user.controller.dto.LoginRequest
+import com.yapp.muckpot.domains.user.controller.dto.UserResponse
+import com.yapp.muckpot.domains.user.exception.UserErrorCode
+import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
+import com.yapp.muckpot.exception.MuckPotException
+import com.yapp.muckpot.redis.RedisService
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserService(
+    private val userRepository: MuckPotUserRepository,
+    private val jwtService: JwtService,
+    private val redisService: RedisService,
+    private val passwordEncoder: PasswordEncoder
+) {
+    @Transactional
+    fun login(request: LoginRequest): UserResponse {
+        userRepository.findByEmail(request.email)?.let {
+            if (!passwordEncoder.matches(request.password, it.password)) {
+                throw MuckPotException(UserErrorCode.LOGIN_FAIL)
+            }
+            val response = UserResponse.of(it)
+            val accessToken = jwtService.generateAccessToken(response, request.keep)
+            val refreshToken = jwtService.generateRefreshToken(request.email, request.keep)
+            redisService.saveRefreshToken(request.email, refreshToken)
+            JwtCookieUtil.addAccessTokenCookie(accessToken)
+            JwtCookieUtil.addRefreshTokenCookie(refreshToken)
+            return response
+        } ?: run {
+            throw MuckPotException(UserErrorCode.LOGIN_FAIL)
+        }
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/exception/GlobalExceptionHandler.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/exception/GlobalExceptionHandler.kt
@@ -1,17 +1,42 @@
 package com.yapp.muckpot.exception
 
 import com.yapp.muckpot.common.ResponseDto
+import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.valueOf
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import javax.validation.ValidationException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
     @ExceptionHandler(MuckPotException::class)
-    fun muckpotGlobalExceptionHandler(e: MuckPotException): ResponseEntity<ResponseDto> {
-        val responseDto = e.errorCode.toResponseDto()
+    fun muckpotGlobalExceptionHandler(exception: MuckPotException): ResponseEntity<ResponseDto> {
+        val responseDto = exception.errorCode.toResponseDto()
         return ResponseEntity.status(valueOf(responseDto.status)).body(responseDto)
+    }
+
+    @ExceptionHandler(IllegalStateException::class)
+    fun internalServerErrorHandler(exception: Exception): ResponseEntity<ResponseDto> {
+        return ResponseEntity.internalServerError()
+            .body(ResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.message))
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun badRequestErrorHandler(exception: Exception): ResponseEntity<ResponseDto> {
+        return ResponseEntity.badRequest()
+            .body(ResponseDto(HttpStatus.BAD_REQUEST.value(), exception.message))
+    }
+
+    @ExceptionHandler(value = [MethodArgumentNotValidException::class, ValidationException::class])
+    fun methodArgumentNotValidExceptionHandler(exception: Exception): ResponseEntity<ResponseDto> {
+        var message = exception.message
+        if (exception is MethodArgumentNotValidException && exception.hasErrors()) {
+            message = exception.allErrors.firstOrNull()?.defaultMessage ?: exception.message
+        }
+        return ResponseEntity.badRequest()
+            .body(ResponseDto(HttpStatus.BAD_REQUEST.value(), message))
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
@@ -1,0 +1,35 @@
+package com.yapp.muckpot.filter
+
+import com.yapp.muckpot.common.LOGIN_URL
+import com.yapp.muckpot.common.ResponseWriter
+import com.yapp.muckpot.common.security.AuthenticationUser
+import com.yapp.muckpot.domains.user.service.JwtService
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        jwtService.getCurrentUserClaim()?.let {
+            if (request.requestURI.equals(LOGIN_URL)) {
+                ResponseWriter.writeResponse(response, HttpStatus.BAD_REQUEST, "이미 로그인한 유저 입니다.")
+                return
+            }
+            val authentication = AuthenticationUser(it.userId, it, true, LOGIN_USER_AUTHORITIES)
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    companion object {
+        private val LOGIN_USER_AUTHORITIES = listOf(SimpleGrantedAuthority("ROLE_USER"))
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/swagger/ResponseExample.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/swagger/ResponseExample.kt
@@ -7,3 +7,12 @@ const val TEST_SAMPLE = """
   "currentTime": "20230515"
 }
 """
+
+const val LOGIN_RESPONSE = """
+    "status": 200,
+    "result": {
+        "userId": 1,
+        "nickName": "nickName"
+    }
+}
+"""

--- a/muckpot-api/src/main/resources/application.yml
+++ b/muckpot-api/src/main/resources/application.yml
@@ -17,3 +17,7 @@ jwt:
 
 logging:
   config: classpath:logback-${spring.config.activate.on-profile}.xml
+
+api:
+  option:
+    permit-all: false # 배포: false, 테스트 : true

--- a/muckpot-api/src/main/resources/application.yml
+++ b/muckpot-api/src/main/resources/application.yml
@@ -11,5 +11,9 @@ spring:
   jpa:
     open-in-view: false
 
+jwt:
+  issuer: "muckpot"
+  secret-key: ${JWT_SECRET_KEY:secret}
+
 logging:
   config: classpath:logback-${spring.config.activate.on-profile}.xml

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/ApplicationTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/ApplicationTest.kt
@@ -1,0 +1,10 @@
+package com.yapp.muckpot
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ApplicationTest {
+    @Test
+    fun contextLoads() {}
+}

--- a/muckpot-api/src/test/resources/application.yml
+++ b/muckpot-api/src/test/resources/application.yml
@@ -14,3 +14,7 @@ spring:
 jwt:
   issuer: "muckpot"
   secret-key: "test-secret"
+
+api:
+  option:
+    permit-all: false

--- a/muckpot-api/src/test/resources/application.yml
+++ b/muckpot-api/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  profiles:
+    active: local
+    include:
+      - domain
+      - infra
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  jpa:
+    open-in-view: false
+
+jwt:
+  issuer: "muckpot"
+  secret-key: "test-secret"

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/ResponseDto.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/ResponseDto.kt
@@ -16,11 +16,11 @@ data class ResponseDto(
         }
 
         fun success(data: Any? = "성공"): ResponseDto {
-            return ResponseDto(status = StatusCode.OK.code, message = "요청에 성공하였습니다.", result = data)
+            return ResponseDto(status = StatusCode.OK.code, null, result = data)
         }
 
         fun created(data: Any? = "성공"): ResponseDto {
-            return ResponseDto(status = StatusCode.CREATED.code, message = "생성에 성공하였습니다.", result = data)
+            return ResponseDto(status = StatusCode.CREATED.code, null, result = data)
         }
     }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/enums/YesNo.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/enums/YesNo.kt
@@ -1,0 +1,5 @@
+package com.yapp.muckpot.common.enums
+
+enum class YesNo {
+    Y, N
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/entity/MuckPotUser.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/entity/MuckPotUser.kt
@@ -43,13 +43,13 @@ class MuckPotUser(
     var mainCategory: String,
 
     @Column(name = "sub_category")
-    var subCategory: String,
+    var subCategory: String? = null,
 
     @Embedded
     var location: Location,
 
     @Column(name = "image_url")
-    var imageUrl: String,
+    var imageUrl: String? = null,
 
     @Column(name = "state")
     @Enumerated(value = EnumType.STRING)
@@ -62,6 +62,5 @@ class MuckPotUser(
         require(nickName.isNotBlank()) { "닉네임은 필수입니다" }
         require(yearOfBirth in 1900..2023) { "잘못된 출생 연도입니다" }
         require(mainCategory.isNotBlank()) { "주요 카테고리는 필수입니다" }
-        require(subCategory.isNotBlank()) { "하위 카테고리는 필수입니다" }
     }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/exception/UserErrorCode.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/exception/UserErrorCode.kt
@@ -1,0 +1,17 @@
+package com.yapp.muckpot.domains.user.exception
+
+import com.yapp.muckpot.common.BaseErrorCode
+import com.yapp.muckpot.common.ResponseDto
+import com.yapp.muckpot.common.enums.StatusCode
+
+enum class UserErrorCode(
+    private val status: Int,
+    private val reason: String
+) : BaseErrorCode {
+    USER_NOT_FOUND(StatusCode.BAD_REQUEST.code, "유저를 찾을 수 없습니다."),
+    LOGIN_FAIL(StatusCode.UNAUTHORIZED.code, "아이디 혹은 비밀번호가 일치하지 않습니다.");
+
+    override fun toResponseDto(): ResponseDto {
+        return ResponseDto(this.status, this.reason, null)
+    }
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/repository/MuckPotUserRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/repository/MuckPotUserRepository.kt
@@ -3,4 +3,6 @@ package com.yapp.muckpot.domains.user.repository
 import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface MuckPotUserRepository : JpaRepository<MuckPotUser, Long>
+interface MuckPotUserRepository : JpaRepository<MuckPotUser, Long> {
+    fun findByEmail(email: String): MuckPotUser?
+}

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/config/CustomDataJpaTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/config/CustomDataJpaTest.kt
@@ -2,8 +2,10 @@ package com.yapp.muckpot.config
 
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
 
 @Target(AnnotationTarget.CLASS)
 @DataJpaTest
+@Import(TestConfig::class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 annotation class CustomDataJpaTest

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/config/TestConfig.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/config/TestConfig.kt
@@ -1,0 +1,18 @@
+package com.yapp.muckpot.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@TestConfiguration
+class TestConfig {
+    @PersistenceContext
+    lateinit var em: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(em)
+    }
+}

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/user/repository/MuckPotUserRepositoryTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/user/repository/MuckPotUserRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.yapp.muckpot.common.enums.Gender
 import com.yapp.muckpot.config.CustomDataJpaTest
 import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -22,5 +23,11 @@ class MuckPotUserRepositoryTest(
         val saveUser = muckPotUserRepository.save(muckPotUser)
         // then
         saveUser.id shouldNotBe null
+    }
+
+    "findByEmail 호출 성공" {
+        val user = muckPotUserRepository.findByEmail("user@samsung.com")
+
+        user shouldBe null
     }
 })

--- a/muckpot-infra/src/main/kotlin/com/yapp/muckpot/redis/RedisService.kt
+++ b/muckpot-infra/src/main/kotlin/com/yapp/muckpot/redis/RedisService.kt
@@ -12,4 +12,8 @@ class RedisService(private val redisTemplate: RedisTemplate<String, Any>) {
         operations.set("test", "테스트")
         return operations.get("test") as String
     }
+
+    fun saveRefreshToken(email: String, refreshToken: String) {
+        redisTemplate.opsForValue().set(email, refreshToken)
+    }
 }

--- a/muckpot-infra/src/main/resources/application-infra.yml
+++ b/muckpot-infra/src/main/resources/application-infra.yml
@@ -3,8 +3,8 @@ spring:
     activate:
       on-profile: local
   redis:
-    host: ${LOCAL_REDIS_HOST}
-    port: ${REDIS_PORT}
+    host: ${LOCAL_REDIS_HOST:localhost}
+    port: ${REDIS_PORT:6379}
 
 ---
 


### PR DESCRIPTION
## 개요
- close #35 

## 작업사항
- 로그인 기능 구현
  - 로그인 수행 시 accesstoken, refreshtoken 쿠키 발급
  - refreshtoken은 redis 저장
  - 기본 유지시간은 1시간, 일주일
  - 로그인 유지하기 클릭시 만료시간 없음

- 비로그인, 로그인 유저 구분
  - 비 로그인 회원: Login API + Get 요청만 가능
  - 로그인 회원: 모든 api 호출 가능

- @cofls6581 .env 파일에 JWT_SECRET_KEY 추가하였습니다.


## 변경로직
- 예외 처리하다보니 공통부분 GlobalExceptionHandler 이 변경되었습니다.
- MuckPotUser 에서 서브카테고리, 이미지 url nullable 변경
- ResponseDto에서 성공 메시지는 null로 바꾸었습니다.
- api 모듈에서 통합테스트 수행시 local 환경에 연결하도록 설정을 변경했습니다.
  - 테스트 컨테이너 구축시도했는데.. 잘안되어서, 우선 local로 붙여놨습니다 ㅠㅠ
  - 테스트 설정하면서 infra모듈에서 redis 포트를 노출시켰습니다. (.env를 못읽히겠어서 default 값을 주었습니다..)
  - ci/cd 스크립트, docker-compose 파일도 변경했습니다.