### PR TITLE
fix: 35-비로그인 유저 가능 api 추가

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtConstant.kt
@@ -1,3 +1,6 @@
 package com.yapp.muckpot.common
 
 const val LOGIN_URL = "/api/v1/users/login"
+const val SIGN_UP_URL = "/api/v1/users"
+const val EMAIL_REQUEST = "/api/v1/emails/request"
+const val EMAIL_VERIFY = "/api/v1/emails/verify"

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
@@ -1,6 +1,9 @@
 package com.yapp.muckpot.config
 
+import com.yapp.muckpot.common.EMAIL_REQUEST
+import com.yapp.muckpot.common.EMAIL_VERIFY
 import com.yapp.muckpot.common.LOGIN_URL
+import com.yapp.muckpot.common.SIGN_UP_URL
 import com.yapp.muckpot.common.security.CustomAuthenticationEntryPoint
 import com.yapp.muckpot.domains.user.service.JwtService
 import com.yapp.muckpot.filter.JwtAuthorizationFilter
@@ -31,8 +34,7 @@ class SecurityConfig(
         http
             .authorizeHttpRequests { authz ->
                 authz
-                    .antMatchers(LOGIN_URL)
-                    .permitAll()
+                    .antMatchers(HttpMethod.POST, *POST_PERMIT_ALL_URLS.toTypedArray()).permitAll()
                     .antMatchers(HttpMethod.GET, "/api/**", "/swagger-ui/**")
                     .permitAll()
                     .antMatchers("/api/**").apply {
@@ -82,5 +84,9 @@ class SecurityConfig(
     @Bean
     fun passwordEncoder(): PasswordEncoder {
         return BCryptPasswordEncoder()
+    }
+
+    companion object {
+        val POST_PERMIT_ALL_URLS = listOf(LOGIN_URL, SIGN_UP_URL, EMAIL_REQUEST, EMAIL_VERIFY)
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
@@ -3,6 +3,7 @@ package com.yapp.muckpot.filter
 import com.yapp.muckpot.common.LOGIN_URL
 import com.yapp.muckpot.common.ResponseWriter
 import com.yapp.muckpot.common.security.AuthenticationUser
+import com.yapp.muckpot.config.SecurityConfig.Companion.POST_PERMIT_ALL_URLS
 import com.yapp.muckpot.domains.user.service.JwtService
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -19,7 +20,7 @@ class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerReques
         filterChain: FilterChain
     ) {
         jwtService.getCurrentUserClaim()?.let {
-            if (request.requestURI.equals(LOGIN_URL)) {
+            if (POST_PERMIT_ALL_URLS.contains(request.requestURI.equals(LOGIN_URL).toString())) {
                 ResponseWriter.writeResponse(response, HttpStatus.BAD_REQUEST, "이미 로그인한 유저 입니다.")
                 return
             }


### PR DESCRIPTION
## 개요
- close #35

## 작업사항

## 변경로직
- 비회원 접근 가능 URL 추가
  - 회원가입, 이메일 인증, 이메일 전송