### PR TITLE
refactor: 44 board refactor

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequest.kt
@@ -5,8 +5,8 @@ import com.yapp.muckpot.common.AGE_MAX
 import com.yapp.muckpot.common.AGE_MIN
 import com.yapp.muckpot.common.CHAT_LINK_MAX
 import com.yapp.muckpot.common.CONTENT_MAX
+import com.yapp.muckpot.common.HHmm
 import com.yapp.muckpot.common.Location
-import com.yapp.muckpot.common.MEETING_TIME
 import com.yapp.muckpot.common.TITLE_MAX
 import com.yapp.muckpot.common.YYYYMMDD
 import com.yapp.muckpot.domains.board.entity.Board
@@ -15,17 +15,18 @@ import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import org.hibernate.validator.constraints.Length
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import javax.validation.constraints.Min
-import javax.validation.constraints.Pattern
 
 @ApiModel(value = "먹팟생성 요청")
 data class MuckpotCreateRequest(
     @field:ApiModelProperty(notes = "만날 날짜", required = true, example = "2023-05-21")
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = YYYYMMDD)
     val meetingDate: LocalDate,
-    @field:ApiModelProperty(notes = "만날 시간", required = true, example = "오후 12:00")
-    @field:Pattern(regexp = MEETING_TIME)
-    val meetingTime: String,
+    @field:ApiModelProperty(notes = "만날 시간", required = true, example = "13:00")
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
+    val meetingTime: LocalTime,
     @field:ApiModelProperty(notes = "최대 인원", required = true, example = "5")
     @field:Min(2, message = "최대 인원은 {value}명 이상 가능합니다.")
     val maxApply: Int = 2,
@@ -41,10 +42,10 @@ data class MuckpotCreateRequest(
     val x: Double,
     @field:ApiModelProperty(notes = "y 좌표", required = true, example = "37.58392327180857")
     val y: Double,
-    @field:ApiModelProperty(notes = "제목", required = true, example = "37.58392327180857")
+    @field:ApiModelProperty(notes = "제목", required = true, example = "같이 밥묵으실분")
     @field:Length(max = TITLE_MAX, message = "제목은 {max}(자)를 넘을 수 없습니다.")
     var title: String,
-    @field:ApiModelProperty(notes = "내용", required = false, example = "같이 밥묵으실분")
+    @field:ApiModelProperty(notes = "내용", required = false, example = "내용 입니다.")
     @field:Length(max = CONTENT_MAX, message = "내용은 {max}(자)를 넘을 수 없습니다.")
     var content: String? = null,
     @field:ApiModelProperty(notes = "오픈채팅방 링크", required = true, example = "https://open.kakao.com/o/gSIkvvHc")
@@ -62,14 +63,15 @@ data class MuckpotCreateRequest(
         return Board(
             user = user,
             title = title,
+            content = content,
             location = Location(locationName, x, y),
             locationDetail = locationDetail,
-            meetingDate = meetingDate,
-            meetingTime = meetingTime,
+            meetingTime = LocalDateTime.of(meetingDate, meetingTime),
             minAge = minAge ?: AGE_MIN,
             maxAge = maxAge ?: AGE_MAX,
             maxApply = maxApply,
-            chatLink = chatLink
+            chatLink = chatLink,
+            currentApply = 1
         )
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/exception/GlobalExceptionHandler.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/exception/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.yapp.muckpot.exception
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.yapp.muckpot.common.ResponseDto
+import mu.KLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.valueOf
 import org.springframework.http.ResponseEntity
@@ -14,27 +15,32 @@ import javax.validation.ValidationException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
+    private val log = KLogging().logger
 
     @ExceptionHandler(MuckPotException::class)
     fun muckpotGlobalExceptionHandler(exception: MuckPotException): ResponseEntity<ResponseDto> {
+        log.info(exception) { "" }
         val responseDto = exception.errorCode.toResponseDto()
         return ResponseEntity.status(valueOf(responseDto.status)).body(responseDto)
     }
 
     @ExceptionHandler(IllegalStateException::class)
     fun internalServerErrorHandler(exception: Exception): ResponseEntity<ResponseDto> {
+        log.info(exception) { "" }
         return ResponseEntity.internalServerError()
             .body(ResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.message))
     }
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun badRequestErrorHandler(exception: Exception): ResponseEntity<ResponseDto> {
+        log.info(exception) { "" }
         return ResponseEntity.badRequest()
             .body(ResponseDto(HttpStatus.BAD_REQUEST.value(), exception.message))
     }
 
     @ExceptionHandler(value = [MethodArgumentNotValidException::class, ValidationException::class])
     fun methodArgumentNotValidExceptionHandler(exception: Exception): ResponseEntity<ResponseDto> {
+        log.info(exception) { "" }
         var message = exception.message
         if (exception is MethodArgumentNotValidException && exception.hasErrors()) {
             message = exception.allErrors.firstOrNull()?.defaultMessage ?: exception.message
@@ -44,9 +50,10 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = [HttpMessageNotReadableException::class])
-    fun httpMessageNotReadableExceptionHandler(ex: HttpMessageNotReadableException): ResponseEntity<ResponseDto> {
-        var message = ex.message
-        val cause = ex.cause
+    fun httpMessageNotReadableExceptionHandler(exception: HttpMessageNotReadableException): ResponseEntity<ResponseDto> {
+        log.info(exception) { "" }
+        var message = exception.message
+        val cause = exception.cause
         if (cause is MissingKotlinParameterException) {
             val name = cause.parameter.name
             message = "{$name}값이 필요합니다."

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequestTest.kt
@@ -6,6 +6,7 @@ import com.yapp.muckpot.common.TITLE_MAX
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
+import java.time.LocalTime
 import javax.validation.ConstraintViolation
 import javax.validation.Validation
 import javax.validation.Validator
@@ -21,7 +22,7 @@ class MuckpotCreateRequestTest : StringSpec({
     beforeEach {
         request = MuckpotCreateRequest(
             meetingDate = LocalDate.now(),
-            meetingTime = "오전 12:00",
+            meetingTime = LocalTime.of(12, 1),
             maxApply = 10,
             minAge = 20,
             maxAge = 100,

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
+import java.time.LocalTime
 
 @SpringBootTest
 class BoardServiceTest @Autowired constructor(
@@ -27,7 +28,7 @@ class BoardServiceTest @Autowired constructor(
     var userId: Long = 0
     val request = MuckpotCreateRequest(
         meetingDate = LocalDate.now(),
-        meetingTime = "오전 12:00",
+        meetingTime = LocalTime.of(12, 0),
         maxApply = 10,
         minAge = 20,
         maxAge = 100,

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/RegexPatternConst.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/RegexPatternConst.kt
@@ -1,8 +1,8 @@
 package com.yapp.muckpot.common
 
 const val EMAIL = "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}"
-const val MEETING_TIME = "^(오전|오후) (0[1-9]|1[0-2]):([0-5][0-9])$"
 const val PW_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}\$"
 
 const val ONLY_NAVER = "^[A-Za-z0-9._%+-]+@naver\\.com\$"
 const val YYYYMMDD = "yyyy-MM-dd"
+const val HHmm = "HH:mm"

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -9,7 +9,7 @@ import com.yapp.muckpot.common.MAX_APPLY_MIN
 import com.yapp.muckpot.common.enums.State
 import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import com.yapp.muckpot.domains.user.enums.MuckPotStatus
-import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.persistence.Column
 import javax.persistence.Embedded
 import javax.persistence.Entity
@@ -44,11 +44,8 @@ class Board(
     @Column(name = "location_detail")
     var locationDetail: String? = null,
 
-    @Column(name = "meeting_date", nullable = false)
-    var meetingDate: LocalDate,
-
     @Column(name = "meeting_time", nullable = false)
-    var meetingTime: String,
+    var meetingTime: LocalDateTime,
 
     @Column(name = "content")
     var content: String? = "",
@@ -84,11 +81,13 @@ class Board(
         require(maxAge in AGE_MIN..AGE_MAX) { AGE_EXP_MSG }
         require(minAge < maxAge) { "최소나이는 최대나이보다 작아야 합니다." }
         require(maxApply >= MAX_APPLY_MIN) { "최대 인원은 ${MAX_APPLY_MIN}명 이상 가능합니다." }
-        participate()
     }
 
     fun participate() {
         require(currentApply < maxApply) { "정원이 초과되었습니다." }
         this.currentApply++
+        if (currentApply == maxApply) {
+            this.status = MuckPotStatus.DONE
+        }
     }
 }

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
@@ -9,7 +9,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import java.lang.IllegalArgumentException
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 class BoardTest : FunSpec({
     val user: MuckPotUser = mockk()
@@ -24,8 +24,7 @@ class BoardTest : FunSpec({
                     title = "title",
                     location = location,
                     locationDetail = null,
-                    meetingDate = LocalDate.now(),
-                    meetingTime = "오전 12:00",
+                    meetingTime = LocalDateTime.now(),
                     content = "content",
                     views = 0,
                     currentApply = 0,
@@ -46,8 +45,7 @@ class BoardTest : FunSpec({
                     title = "title",
                     location = location,
                     locationDetail = null,
-                    meetingDate = LocalDate.now(),
-                    meetingTime = "오전 12:00",
+                    meetingTime = LocalDateTime.now(),
                     content = "content",
                     views = 0,
                     currentApply = 0,
@@ -67,11 +65,10 @@ class BoardTest : FunSpec({
                 title = "title",
                 location = location,
                 locationDetail = null,
-                meetingDate = LocalDate.now(),
-                meetingTime = "오전 12:00",
+                meetingTime = LocalDateTime.now(),
                 content = "content",
                 views = 0,
-                currentApply = 0,
+                currentApply = 1,
                 maxApply = 2,
                 chatLink = "link",
                 status = MuckPotStatus.IN_PROGRESS,

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantRepositoryTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantRepositoryTest.kt
@@ -11,7 +11,7 @@ import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldNotBe
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 @CustomDataJpaTest
 class ParticipantRepositoryTest(
@@ -29,7 +29,7 @@ class ParticipantRepositoryTest(
         )
         val board = Board(
             null, user, "title", location, null,
-            LocalDate.now(), "오전 12:00", "content", 0, 0, 3, "link",
+            LocalDateTime.now(), "content", 0, 0, 3, "link",
             MuckPotStatus.IN_PROGRESS, 21, 23
         )
         muckPotUserRepository.save(user)


### PR DESCRIPTION
## 개요
- close #44

## 작업사항
### Board 테이블 변경
- 최초 as-is로 구성했는데.. time을 문자열로 따로 관리하면 조회과정에서 계속 조합이 필요할듯하여 하나로 통합하였습니다.
  - 먹팟 글 리스트 조회 시 필요: n분전, 날짜 응답
  - 기간이 지난 먹팟 글 만료 시 필요
- as-is
``` kotlin
    @Column(name = "meeting_date", nullable = false)
    var meetingDate: LocalDate,

    @Column(name = "meeting_time", nullable = false)
    var meetingTime: String,
```

- to-be
``` kotlin
    @Column(name = "meeting_time", nullable = false)
    var meetingTime: LocalDateTime
```



## 변경로직
- 조회시 관리 편의성을 위해 먹팟 만나는 시간을 LocalDateTime으로 통합
- 변경에 따른 먹팟 생성 API Request 수정
- 예외 발생 시 로그가 안남아서.. GlobalExceptionHadler 모든 메서드에 info 레벨 로깅을 추가하였습니다 !