### PR TITLE
feat:43 먹팟 조회 api 구현

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
@@ -41,3 +41,48 @@ const val MUCKPOT_SAVE_RESPONSE = """
   }
 }
 """
+
+const val MUCKPOT_FIND_ALL = """
+{
+  "status": 200,
+  "result": {
+    "list": [
+      {
+        "boardId": 75,
+        "title": "같이 밥묵으실분",
+        "status": "모집마감",
+        "todayOrTomorrow": "오늘",
+        "elapsedTime": "0분 전",
+        "meetingTime": "04월 01일 (토) 오후 01:00",
+        "meetingPlace": "서울 성북구 안암동5가 104-30 캐치카페 안암",
+        "maxApply": 5,
+        "currentApply": 1,
+        "participants": [
+          {
+            "userId": 48,
+            "nickName": "nickname2"
+          }
+        ]
+      },
+      {
+        "boardId": 74,
+        "title": "같이 밥묵으실분",
+        "status": "모집중",
+        "todayOrTomorrow": "오늘",
+        "elapsedTime": "0분 전",
+        "meetingTime": "07월 01일 (토) 오후 01:00",
+        "meetingPlace": "서울 성북구 안암동5가 104-30 캐치카페 안암",
+        "maxApply": 5,
+        "currentApply": 1,
+        "participants": [
+          {
+            "userId": 48,
+            "nickName": "nickname2"
+          }
+        ]
+      }
+    ],
+    "lastId": 74
+  }
+}
+"""

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
@@ -64,24 +64,6 @@ const val MUCKPOT_FIND_ALL = """
           }
         ]
       },
-      {
-        "boardId": 74,
-        "title": "타이틀",
-        "status": "모집중",
-        "todayOrTomorrow": "오늘",
-        "elapsedTime": "0분 전",
-        "meetingTime": "07월 01일 (토) 오후 01:00",
-        "meetingPlace": "경기도 용인시 기흥구",
-        "maxApply": 4,
-        "currentApply": 2,
-        "participants": [
-          {
-            "userId": 2,
-            "nickName": "hi"
-          }
-        ]
-      }
-    ],
     "lastId": 74
   }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
@@ -66,18 +66,18 @@ const val MUCKPOT_FIND_ALL = """
       },
       {
         "boardId": 74,
-        "title": "같이 밥묵으실분",
+        "title": "타이틀",
         "status": "모집중",
         "todayOrTomorrow": "오늘",
         "elapsedTime": "0분 전",
         "meetingTime": "07월 01일 (토) 오후 01:00",
-        "meetingPlace": "서울 성북구 안암동5가 104-30 캐치카페 안암",
-        "maxApply": 5,
-        "currentApply": 1,
+        "meetingPlace": "경기도 용인시 기흥구",
+        "maxApply": 4,
+        "currentApply": 2,
         "participants": [
           {
-            "userId": 48,
-            "nickName": "nickname2"
+            "userId": 2,
+            "nickName": "hi"
           }
         ]
       }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/dto/CursorPaginationRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/dto/CursorPaginationRequest.kt
@@ -1,0 +1,16 @@
+package com.yapp.muckpot.common.dto
+
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiParam
+
+@ApiModel(value = "커서기반 페이지요청(무한 스크롤)")
+data class CursorPaginationRequest(
+    @field:ApiParam(value = "마지막 ID, 기본 null", required = false)
+    var lastId: Long? = null,
+    @field:ApiParam(value = "스크롤 당 데이터 크기, 기본 $COUNT_PER_SCROLL_DEFAULT", required = false)
+    var countPerScroll: Long = COUNT_PER_SCROLL_DEFAULT
+) {
+    companion object {
+        private const val COUNT_PER_SCROLL_DEFAULT = 10L
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/dto/CursorPaginationResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/dto/CursorPaginationResponse.kt
@@ -5,8 +5,8 @@ import io.swagger.annotations.ApiModelProperty
 
 @ApiModel(value = "커서기반 페이지요청 결과(무한 스크롤)")
 data class CursorPaginationResponse<T>(
-    @ApiModelProperty(notes = "데이터 리스트")
+    @field:ApiModelProperty(notes = "데이터 리스트")
     val list: List<T>,
-    @ApiModelProperty(example = "11", notes = "마지막 id")
-    val lastId: Long?
+    @field:ApiModelProperty(example = "11", notes = "마지막 id")
+    val lastId: Long? = null
 )

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/dto/CursorPaginationResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/dto/CursorPaginationResponse.kt
@@ -1,0 +1,12 @@
+package com.yapp.muckpot.common.dto
+
+import io.swagger.annotations.ApiModel
+import io.swagger.annotations.ApiModelProperty
+
+@ApiModel(value = "커서기반 페이지요청 결과(무한 스크롤)")
+data class CursorPaginationResponse<T>(
+    @ApiModelProperty(notes = "데이터 리스트")
+    val list: List<T>,
+    @ApiModelProperty(example = "11", notes = "마지막 id")
+    val lastId: Long?
+)

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
@@ -2,9 +2,11 @@ package com.yapp.muckpot.domains.board.controller
 
 import com.yapp.muckpot.common.ResponseDto
 import com.yapp.muckpot.common.ResponseEntityUtil
+import com.yapp.muckpot.common.dto.CursorPaginationRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateResponse
 import com.yapp.muckpot.domains.board.service.BoardService
+import com.yapp.muckpot.swagger.MUCKPOT_FIND_ALL
 import com.yapp.muckpot.swagger.MUCKPOT_SAVE_RESPONSE
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
@@ -15,6 +17,8 @@ import io.swagger.annotations.ExampleProperty
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -27,7 +31,6 @@ import javax.validation.Valid
 class BoardController(
     private val boardService: BoardService
 ) {
-
     @ApiResponses(
         value = [
             ApiResponse(
@@ -54,5 +57,25 @@ class BoardController(
                 boardService.saveBoard(userId, request)
             )
         )
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 200,
+                examples = Example(
+                    ExampleProperty(
+                        value = MUCKPOT_FIND_ALL,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "먹팟 글 리스트 조회")
+    @GetMapping("/v1/boards")
+    fun findAll(@ModelAttribute request: CursorPaginationRequest): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.ok(boardService.findAllMuckpot(request))
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotReadResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotReadResponse.kt
@@ -1,0 +1,54 @@
+package com.yapp.muckpot.domains.board.controller.dto
+
+import com.yapp.muckpot.common.TimeUtil
+import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
+import com.yapp.muckpot.domains.board.entity.Board
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus
+
+data class MuckpotReadResponse(
+    val boardId: Long?,
+    val title: String,
+    val status: String,
+    val todayOrTomorrow: String?,
+    val elapsedTime: String,
+    val meetingTime: String,
+    val meetingPlace: String,
+    val maxApply: Int,
+    val currentApply: Int,
+    var participants: List<ParticipantReadResponse>
+) {
+    init {
+        limitParticipants()
+    }
+
+    private fun limitParticipants() {
+        if (participants.size > PARTICIPANTS_MAX_CNT) {
+            participants = participants.take(PARTICIPANTS_MAX_CNT) +
+                ParticipantReadResponse.otherN(participants.size - PARTICIPANTS_MAX_CNT)
+        }
+    }
+
+    companion object {
+        private const val PARTICIPANTS_MAX_CNT = 5
+
+        fun of(board: Board, participants: List<ParticipantReadResponse>): MuckpotReadResponse {
+            // TODO 만료 된 먹팟 종료 처리 후, 해당 로직은 제거.
+            var status = board.status.krNm
+            if (board.expired()) {
+                status = MuckPotStatus.DONE.krNm
+            }
+            return MuckpotReadResponse(
+                boardId = board.id,
+                title = board.title,
+                status = status,
+                todayOrTomorrow = TimeUtil.isTodayOrTomorrow(board.createdAt.toLocalDate()),
+                elapsedTime = TimeUtil.formatElapsedTime(board.createdAt),
+                meetingTime = TimeUtil.formatMeetingTime(board.meetingTime),
+                meetingPlace = board.location.locationName,
+                maxApply = board.maxApply,
+                currentApply = board.currentApply,
+                participants = participants
+            )
+        }
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -40,10 +40,9 @@ class BoardService(
         val boardIds = allBoard.map { it.id }
         val participantsByBoardId = participantQuerydslRepository.findByBoardIds(boardIds).groupBy { it.boardId }
         val responseList = allBoard.map { MuckpotReadResponse.of(it, participantsByBoardId.getOrDefault(it.id, emptyList())) }
-        var lastId: Long? = null
-        if (responseList.size.toLong() == request.countPerScroll) {
-            lastId = responseList.last().boardId
+        if (responseList.isNotEmpty()) {
+            return CursorPaginationResponse(responseList, responseList.last().boardId)
         }
-        return CursorPaginationResponse(responseList, lastId)
+        return CursorPaginationResponse(responseList)
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -1,8 +1,13 @@
 package com.yapp.muckpot.domains.board.service
 
+import com.yapp.muckpot.common.dto.CursorPaginationRequest
+import com.yapp.muckpot.common.dto.CursorPaginationResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
+import com.yapp.muckpot.domains.board.controller.dto.MuckpotReadResponse
 import com.yapp.muckpot.domains.board.entity.Participant
+import com.yapp.muckpot.domains.board.repository.BoardQuerydslRepository
 import com.yapp.muckpot.domains.board.repository.BoardRepository
+import com.yapp.muckpot.domains.board.repository.ParticipantQuerydslRepository
 import com.yapp.muckpot.domains.board.repository.ParticipantRepository
 import com.yapp.muckpot.domains.user.exception.UserErrorCode
 import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
@@ -15,7 +20,9 @@ import org.springframework.transaction.annotation.Transactional
 class BoardService(
     private val userRepository: MuckPotUserRepository,
     private val boardRepository: BoardRepository,
-    private val participantRepository: ParticipantRepository
+    private val boardQuerydslRepository: BoardQuerydslRepository,
+    private val participantRepository: ParticipantRepository,
+    private val participantQuerydslRepository: ParticipantQuerydslRepository
 ) {
     @Transactional
     fun saveBoard(userId: Long, request: MuckpotCreateRequest): Long? {
@@ -25,5 +32,18 @@ class BoardService(
         val board = boardRepository.save(request.toBoard(user))
         participantRepository.save(Participant(user, board))
         return board.id
+    }
+
+    @Transactional(readOnly = true)
+    fun findAllMuckpot(request: CursorPaginationRequest): CursorPaginationResponse<MuckpotReadResponse> {
+        val allBoard = boardQuerydslRepository.findAllWithPagination(request.lastId, request.countPerScroll)
+        val boardIds = allBoard.map { it.id }
+        val participantsByBoardId = participantQuerydslRepository.findByBoardIds(boardIds).groupBy { it.boardId }
+        val responseList = allBoard.map { MuckpotReadResponse.of(it, participantsByBoardId.getOrDefault(it.id, emptyList())) }
+        var lastId: Long? = null
+        if (responseList.size.toLong() == request.countPerScroll) {
+            lastId = responseList.last().boardId
+        }
+        return CursorPaginationResponse(responseList, lastId)
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/exception/GlobalExceptionHandler.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/exception/GlobalExceptionHandler.kt
@@ -24,13 +24,6 @@ class GlobalExceptionHandler {
         return ResponseEntity.status(valueOf(responseDto.status)).body(responseDto)
     }
 
-    @ExceptionHandler(IllegalStateException::class)
-    fun internalServerErrorHandler(exception: Exception): ResponseEntity<ResponseDto> {
-        log.error(exception) { "" }
-        return ResponseEntity.internalServerError()
-            .body(ResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.message))
-    }
-
     @ExceptionHandler(IllegalArgumentException::class)
     fun badRequestErrorHandler(exception: Exception): ResponseEntity<ResponseDto> {
         log.error(exception) { "" }
@@ -62,5 +55,12 @@ class GlobalExceptionHandler {
         }
         return ResponseEntity.badRequest()
             .body(ResponseDto(HttpStatus.BAD_REQUEST.value(), message))
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun internalServerErrorHandler(exception: Exception): ResponseEntity<ResponseDto> {
+        log.error(exception) { "" }
+        return ResponseEntity.internalServerError()
+            .body(ResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.message))
     }
 }

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/common/TimeUtilTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/common/TimeUtilTest.kt
@@ -1,0 +1,93 @@
+package com.yapp.muckpot.common
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.row
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.time.LocalDateTime
+
+class TimeUtilTest : FunSpec({
+    val today = LocalDateTime.now()
+    val yesterday = today.minusDays(1)
+    val tomorrow = today.plusDays(1)
+
+    context("오늘 내일 테스트") {
+        withData(
+            nameFn = { "${it.b} 응답하는 경우" },
+            row(today, TODAY_KR),
+            row(tomorrow, TOMORROW_KR),
+            row(yesterday, null)
+        ) { (localDate, expect) ->
+            // when & then
+            TimeUtil.isTodayOrTomorrow(localDate.toLocalDate()) shouldBe expect
+        }
+    }
+
+    context("시간 정책 - 60분 미만") {
+        withData(
+            nameFn = { "${it.a}분 전" },
+            row(0L),
+            row(1L),
+            row(59L)
+        ) { (minute) ->
+            // when & then
+            TimeUtil.formatElapsedTime(
+                today.minusMinutes(minute)
+            ) shouldBe N_MINUTES_AGO.format(minute)
+        }
+    }
+
+    context("시간 정책 - 1시간 이상 ~ 24시간 미만") {
+        withData(
+            nameFn = { "${it.a}시간 전" },
+            row(1L),
+            row(23L)
+        ) { (hour) ->
+            // when & then
+            TimeUtil.formatElapsedTime(
+                today.minusHours(hour)
+            ) shouldBe N_HOURS_AGO.format(hour)
+        }
+    }
+
+    context("시간 정책 - 24시간 이상 ~ 48시간 미만") {
+        withData(
+            nameFn = { "${it.a}시간 이전" },
+            row(24L),
+            row(47L)
+        ) { (hour) ->
+            // when & then
+            TimeUtil.formatElapsedTime(
+                today.minusHours(hour)
+            ) shouldBe A_DAY_AGO
+        }
+    }
+
+    context("시간 정책 - 48시간 이상") {
+        withData(
+            nameFn = { "${it.a}시간 이전" },
+            row(48L),
+            row(100L)
+        ) { (hour) ->
+            val localDateTime = today.minusHours(hour)
+            // when & then
+            TimeUtil.formatElapsedTime(localDateTime) shouldBe localDateTime.toLocalDate().toString()
+        }
+    }
+
+    context("formatMeetingTime 테스트") {
+        withData(
+            nameFn = { "${it.a}:${it.b}" },
+            row(0, 0, "오전"),
+            row(11, 59, "오전"),
+            row(12, 0, "오후"),
+            row(23, 59, "오후")
+        ) { (hour, minute, amPm) ->
+            // given
+            val localDateTime = LocalDateTime.of(2023, 1, 1, hour, minute)
+            // when & then
+            TimeUtil.formatMeetingTime(localDateTime) shouldContain amPm
+        }
+    }
+})

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
@@ -1,0 +1,73 @@
+package com.yapp.muckpot.domains.board.service
+
+import com.ninjasquad.springmockk.MockkBean
+import com.yapp.muckpot.common.dto.CursorPaginationRequest
+import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
+import com.yapp.muckpot.domains.board.repository.BoardQuerydslRepository
+import com.yapp.muckpot.domains.board.repository.ParticipantQuerydslRepository
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus
+import com.yapp.muckpot.fixture.Fixture
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class BoardServiceMockTest @Autowired constructor(
+    private val boardService: BoardService,
+    @MockkBean
+    private val boardQuerydslRepository: BoardQuerydslRepository,
+    @MockkBean
+    private val participantQuerydslRepository: ParticipantQuerydslRepository
+) : StringSpec({
+    val allBoardSize = 3
+
+    val allBoard = listOf(
+        Fixture.createBoard(id = 1, title = "board1"),
+        Fixture.createBoard(id = 2, title = "board2"),
+        Fixture.createBoard(id = 3, title = "board3")
+    )
+    val participantResponses = listOf(
+        ParticipantReadResponse(boardId = 1, userId = 1, nickName = "user1"),
+        ParticipantReadResponse(boardId = 1, userId = 2, nickName = "user2"),
+        ParticipantReadResponse(boardId = 1, userId = 3, nickName = "user3"),
+        ParticipantReadResponse(boardId = 1, userId = 4, nickName = "user4"),
+        ParticipantReadResponse(boardId = 1, userId = 5, nickName = "user5"),
+        ParticipantReadResponse(boardId = 1, userId = 6, nickName = "user6"),
+        ParticipantReadResponse(boardId = 1, userId = 7, nickName = "user7"),
+        ParticipantReadResponse(boardId = 1, userId = 8, nickName = "user8"),
+        ParticipantReadResponse(boardId = 2, userId = 1, nickName = "user1"),
+        ParticipantReadResponse(boardId = 2, userId = 2, nickName = "user2"),
+        ParticipantReadResponse(boardId = 3, userId = 1, nickName = "user1")
+    )
+
+    beforeTest {
+        // given
+        every { boardQuerydslRepository.findAllWithPagination(any(), any()) } returns allBoard
+        every { participantQuerydslRepository.findByBoardIds(any()) } returns participantResponses
+    }
+
+    "모든 먹팟 조회 성공" {
+        // when
+        val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
+        // then
+        actual.list shouldHaveSize 3
+        actual.lastId shouldBe allBoard.last().id
+    }
+
+    "참가자가 6명을 넘어가면 마지막에 외N 명으로 응답한다" {
+        // when
+        val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
+        // then
+        actual.list[0].participants.last().nickName shouldBe "외 3명"
+    }
+
+    "현재 시간 이전인 경우 모집마감 으로 바꾸어 응답한다." {
+        // when
+        val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
+        // then
+        actual.list[0].status shouldBe MuckPotStatus.DONE.krNm
+    }
+})

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/fixture/Fixture.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/fixture/Fixture.kt
@@ -1,0 +1,87 @@
+package com.yapp.muckpot.fixture
+
+import com.yapp.muckpot.common.AGE_MAX
+import com.yapp.muckpot.common.AGE_MIN
+import com.yapp.muckpot.common.Location
+import com.yapp.muckpot.common.enums.Gender
+import com.yapp.muckpot.common.enums.State
+import com.yapp.muckpot.domains.board.entity.Board
+import com.yapp.muckpot.domains.board.entity.Participant
+import com.yapp.muckpot.domains.board.entity.ParticipantId
+import com.yapp.muckpot.domains.user.entity.MuckPotUser
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus
+import java.time.LocalDateTime
+import java.util.*
+
+object Fixture {
+    fun createUser(
+        id: Long? = null,
+        email: String = UUID.randomUUID().toString().substring(0, 5) + "@naver.com",
+        password: String = "abcd1234",
+        nickName: String = UUID.randomUUID().toString(),
+        gender: Gender = Gender.MEN,
+        yearOfBirth: Int = 2000,
+        mainCategory: String = "mainCategory",
+        subCategory: String? = "subCategory",
+        location: Location = Location("userLocation", 40.7128, -74.0060),
+        imageUrl: String? = "image_url",
+        state: State = State.ACTIVE
+    ): MuckPotUser {
+        return MuckPotUser(
+            id,
+            email,
+            password,
+            nickName,
+            gender,
+            yearOfBirth,
+            mainCategory,
+            subCategory,
+            location,
+            imageUrl,
+            state
+        )
+    }
+
+    fun createBoard(
+        id: Long? = null,
+        user: MuckPotUser? = createUser(),
+        title: String = "board_title",
+        location: Location = Location("boardLocation", 40.7128, -74.0060),
+        locationDetail: String? = null,
+        meetingTime: LocalDateTime = LocalDateTime.now(),
+        content: String? = "content",
+        views: Int = 0,
+        currentApply: Int = 0,
+        maxApply: Int = 2,
+        chatLink: String = "chat_link",
+        status: MuckPotStatus = MuckPotStatus.IN_PROGRESS,
+        minAge: Int = AGE_MIN,
+        maxAge: Int = AGE_MAX,
+        state: State = State.ACTIVE
+    ): Board {
+        return Board(
+            id,
+            user,
+            title,
+            location,
+            locationDetail,
+            meetingTime,
+            content,
+            views,
+            currentApply,
+            maxApply,
+            chatLink,
+            status,
+            minAge,
+            maxAge,
+            state
+        )
+    }
+
+    fun createParticipant(
+        participantId: ParticipantId = ParticipantId(createUser(), createBoard()),
+        state: State = State.ACTIVE
+    ): Participant {
+        return Participant(participantId = participantId, state = state)
+    }
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeConstant.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeConstant.kt
@@ -1,0 +1,15 @@
+package com.yapp.muckpot.common
+
+val NOT_TODAY_OR_TOMORROW = null
+const val TODAY_KR = "오늘"
+const val TOMORROW_KR = "내일"
+
+const val HOUR_IN_MINUTES = 60
+const val MINUTES_IN_ONE_DAY = 1440
+const val MINUTES_IN_TWO_DAY = 2880
+
+const val N_MINUTES_AGO = "%d분 전"
+const val N_HOURS_AGO = "%d시간 전"
+const val A_DAY_AGO = "하루 전"
+
+const val MEETING_TIME_PATTERN = "MM월 dd일 (E) a hh:mm"

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeUtil.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeUtil.kt
@@ -29,14 +29,11 @@ object TimeUtil {
      */
     fun formatElapsedTime(localDateTime: LocalDateTime): String {
         val timeDiff = ChronoUnit.MINUTES.between(localDateTime, LocalDateTime.now())
-        return if (timeDiff < HOUR_IN_MINUTES) {
-            N_MINUTES_AGO.format(timeDiff)
-        } else if (timeDiff in HOUR_IN_MINUTES until MINUTES_IN_ONE_DAY) {
-            N_HOURS_AGO.format(timeDiff / HOUR_IN_MINUTES)
-        } else if (timeDiff in MINUTES_IN_ONE_DAY until MINUTES_IN_TWO_DAY) {
-            A_DAY_AGO
-        } else {
-            localDateTime.toLocalDate().toString()
+        return when {
+            (timeDiff < HOUR_IN_MINUTES) -> N_MINUTES_AGO.format(timeDiff)
+            (timeDiff in HOUR_IN_MINUTES until MINUTES_IN_ONE_DAY) -> N_HOURS_AGO.format(timeDiff / HOUR_IN_MINUTES)
+            (timeDiff in MINUTES_IN_ONE_DAY until MINUTES_IN_TWO_DAY) -> A_DAY_AGO
+            else -> localDateTime.toLocalDate().toString()
         }
     }
 

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeUtil.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeUtil.kt
@@ -1,0 +1,47 @@
+package com.yapp.muckpot.common
+
+import com.yapp.muckpot.common.extension.isToday
+import com.yapp.muckpot.common.extension.isTomorrow
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+object TimeUtil {
+    /**
+     * 현재 시간을 기준으로 오늘, 내일 계산
+     *
+     * @return 오늘, 내일, null
+     */
+    fun isTodayOrTomorrow(localDate: LocalDate): String? {
+        var todayOrTomorrow: String? = NOT_TODAY_OR_TOMORROW
+        if (localDate.isToday()) {
+            todayOrTomorrow = TODAY_KR
+        } else if (localDate.isTomorrow()) {
+            todayOrTomorrow = TOMORROW_KR
+        }
+        return todayOrTomorrow
+    }
+
+    /**
+     * @param localDateTime localDateTime 이 현재시간부터 얼마큼 지났는지 정책에 따라 계산
+     */
+    fun formatElapsedTime(localDateTime: LocalDateTime): String {
+        val timeDiff = ChronoUnit.MINUTES.between(localDateTime, LocalDateTime.now())
+        return if (timeDiff < HOUR_IN_MINUTES) {
+            N_MINUTES_AGO.format(timeDiff)
+        } else if (timeDiff in HOUR_IN_MINUTES until MINUTES_IN_ONE_DAY) {
+            N_HOURS_AGO.format(timeDiff / HOUR_IN_MINUTES)
+        } else if (timeDiff in MINUTES_IN_ONE_DAY until MINUTES_IN_TWO_DAY) {
+            A_DAY_AGO
+        } else {
+            localDateTime.toLocalDate().toString()
+        }
+    }
+
+    fun formatMeetingTime(localDateTime: LocalDateTime): String {
+        val formatter = DateTimeFormatter.ofPattern(MEETING_TIME_PATTERN, Locale.KOREAN)
+        return localDateTime.format(formatter)
+    }
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/extension/LocalDate.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/extension/LocalDate.kt
@@ -1,0 +1,11 @@
+package com.yapp.muckpot.common.extension
+
+import java.time.LocalDate
+
+fun LocalDate.isToday(): Boolean {
+    return this == LocalDate.now()
+}
+
+fun LocalDate.isTomorrow(): Boolean {
+    return this == LocalDate.now().plusDays(1)
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/dto/ParticipantReadResponse.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/dto/ParticipantReadResponse.kt
@@ -1,0 +1,21 @@
+package com.yapp.muckpot.domains.board.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.querydsl.core.annotations.QueryProjection
+
+data class ParticipantReadResponse @QueryProjection constructor(
+    @JsonIgnore
+    val boardId: Long? = null,
+    val userId: Long?,
+    val nickName: String
+) {
+    companion object {
+        fun otherN(otherCnt: Int): ParticipantReadResponse {
+            return ParticipantReadResponse(
+                null,
+                null,
+                "외 ${otherCnt}명"
+            )
+        }
+    }
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -90,4 +90,8 @@ class Board(
             this.status = MuckPotStatus.DONE
         }
     }
+
+    fun expired(): Boolean {
+        return (this.status == MuckPotStatus.IN_PROGRESS && this.meetingTime.isBefore(LocalDateTime.now()))
+    }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepository.kt
@@ -1,0 +1,29 @@
+package com.yapp.muckpot.domains.board.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yapp.muckpot.domains.board.entity.Board
+import com.yapp.muckpot.domains.board.entity.QBoard.board
+import org.springframework.stereotype.Repository
+
+@Repository
+class BoardQuerydslRepository(
+    private val queryFactory: JPAQueryFactory
+) {
+    fun findAllWithPagination(lastId: Long?, countPerScroll: Long): List<Board> {
+        return queryFactory.from(board)
+            .select(board)
+            .where(
+                lessThanLastId(lastId)
+            )
+            .orderBy(board.createdAt.desc())
+            .limit(countPerScroll)
+            .fetch()
+    }
+
+    private fun lessThanLastId(lastId: Long?): BooleanExpression? {
+        return lastId?.let {
+            board.id.lt(it)
+        }
+    }
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantQuerydslRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantQuerydslRepository.kt
@@ -1,0 +1,26 @@
+package com.yapp.muckpot.domains.board.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
+import com.yapp.muckpot.domains.board.dto.QParticipantReadResponse
+import com.yapp.muckpot.domains.board.entity.QParticipant.participant
+import org.springframework.stereotype.Repository
+
+@Repository
+class ParticipantQuerydslRepository(
+    private val queryFactory: JPAQueryFactory
+) {
+    fun findByBoardIds(boardIds: List<Long?>): List<ParticipantReadResponse> {
+        return queryFactory.select(
+            QParticipantReadResponse(
+                participant.participantId.board.id,
+                participant.participantId.user.id,
+                participant.participantId.user.nickName
+            )
+        )
+            .from(participant)
+            .where(participant.participantId.board.id.`in`(boardIds))
+            .orderBy(participant.createdAt.asc())
+            .fetch()
+    }
+}

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/enums/MuckPotStatus.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/enums/MuckPotStatus.kt
@@ -1,5 +1,7 @@
 package com.yapp.muckpot.domains.user.enums
 
-enum class MuckPotStatus {
-    IN_PROGRESS, HOLD, DONE
+enum class MuckPotStatus(
+    val krNm: String
+) {
+    IN_PROGRESS("모집중"), DONE("모집마감")
 }

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepositoryTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/BoardQuerydslRepositoryTest.kt
@@ -1,0 +1,60 @@
+package com.yapp.muckpot.domains.board.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yapp.muckpot.config.CustomDataJpaTest
+import com.yapp.muckpot.domains.board.entity.Board
+import com.yapp.muckpot.domains.user.entity.MuckPotUser
+import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
+import com.yapp.muckpot.fixture.Fixture
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+@CustomDataJpaTest
+class BoardQuerydslRepositoryTest(
+    private val userRepository: MuckPotUserRepository,
+    private val boardRepository: BoardRepository,
+    private val jpaQueryFactory: JPAQueryFactory
+) : StringSpec({
+    val boardQuerydslRepository = BoardQuerydslRepository(jpaQueryFactory)
+
+    lateinit var user: MuckPotUser
+    lateinit var boards: List<Board>
+
+    val firstCreated = LocalDateTime.now()
+    val secondCreated = LocalDateTime.now().minusDays(1)
+    val thirdCreated = LocalDateTime.now().minusDays(2)
+
+    beforeEach {
+        user = Fixture.createUser()
+        boards = listOf(
+            Fixture.createBoard(title = "board1", user = user).apply { createdAt = firstCreated },
+            Fixture.createBoard(title = "board2", user = user).apply { createdAt = thirdCreated },
+            Fixture.createBoard(title = "board3", user = user).apply { createdAt = secondCreated }
+        )
+
+        userRepository.save(user)
+        boardRepository.saveAll(boards)
+    }
+
+    afterEach {
+        boardRepository.deleteAll()
+        userRepository.deleteAll()
+    }
+
+    "countPerScroll이 2인 경우" {
+        val countPerScroll = 2
+        // when
+        val result = boardQuerydslRepository.findAllWithPagination(null, countPerScroll.toLong())
+        // then
+        result shouldHaveSize countPerScroll
+    }
+
+    "생성일자 기준 내림차순 정렬" {
+        // when
+        val result = boardQuerydslRepository.findAllWithPagination(null, 3)
+        // then
+        result.last().id shouldBe boards[1].id
+    }
+})

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantQuerydslRepositoryTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantQuerydslRepositoryTest.kt
@@ -1,0 +1,74 @@
+package com.yapp.muckpot.domains.board.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.yapp.muckpot.config.CustomDataJpaTest
+import com.yapp.muckpot.domains.board.entity.Board
+import com.yapp.muckpot.domains.board.entity.Participant
+import com.yapp.muckpot.domains.board.entity.ParticipantId
+import com.yapp.muckpot.domains.user.entity.MuckPotUser
+import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
+import com.yapp.muckpot.fixture.Fixture
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+@CustomDataJpaTest
+class ParticipantQuerydslRepositoryTest(
+    private val participantRepository: ParticipantRepository,
+    private val userRepository: MuckPotUserRepository,
+    private val boardRepository: BoardRepository,
+    private val jpaQueryFactory: JPAQueryFactory
+) : StringSpec({
+    val participantQuerydslRepository = ParticipantQuerydslRepository(jpaQueryFactory)
+
+    lateinit var users: List<MuckPotUser>
+    lateinit var boards: List<Board>
+    lateinit var participants: List<Participant>
+
+    beforeEach {
+        users = listOf(
+            Fixture.createUser(),
+            Fixture.createUser(),
+            Fixture.createUser()
+        )
+        boards = listOf(
+            Fixture.createBoard(user = users[0]),
+            Fixture.createBoard(title = "board2", user = users[0]),
+            Fixture.createBoard(title = "board3", user = users[0])
+        )
+        participants = listOf(
+            Fixture.createParticipant(ParticipantId(users[0], boards[0])),
+            Fixture.createParticipant(ParticipantId(users[1], boards[0])),
+            Fixture.createParticipant(ParticipantId(users[0], boards[1])),
+            Fixture.createParticipant(ParticipantId(users[0], boards[2]))
+                .apply { createdAt = LocalDateTime.now().minusDays(3) }
+        )
+        userRepository.saveAll(users)
+        boardRepository.saveAll(boards)
+        participantRepository.saveAll(participants)
+    }
+
+    afterEach {
+        participantRepository.deleteAll()
+        boardRepository.deleteAll()
+        userRepository.deleteAll()
+    }
+
+    "먹팟_ID 리스트를 조건으로 조회 성공" {
+        val boardIds = listOf(boards[0].id, boards[2].id)
+        // when
+        val actual = participantQuerydslRepository.findByBoardIds(boardIds)
+        // then
+        actual shouldHaveSize 3
+    }
+
+    "참여자 목록은 빠른 순서 정렬" {
+        val boardIds = listOf(boards[0].id, boards[2].id)
+        // when
+        val actual = participantQuerydslRepository.findByBoardIds(boardIds).first()
+        // then
+        actual.boardId shouldBe participants[3].participantId.board.id
+        actual.userId shouldBe participants[3].participantId.user.id
+    }
+})

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantRepositoryTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantRepositoryTest.kt
@@ -1,17 +1,12 @@
 package com.yapp.muckpot.domains.board.repository
 
-import com.yapp.muckpot.common.Location
-import com.yapp.muckpot.common.enums.Gender
 import com.yapp.muckpot.config.CustomDataJpaTest
-import com.yapp.muckpot.domains.board.entity.Board
 import com.yapp.muckpot.domains.board.entity.Participant
-import com.yapp.muckpot.domains.user.entity.MuckPotUser
-import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
+import com.yapp.muckpot.fixture.Fixture
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldNotBe
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDateTime
 
 @CustomDataJpaTest
 class ParticipantRepositoryTest(
@@ -22,16 +17,8 @@ class ParticipantRepositoryTest(
 
     "Participant 데이터 저장 성공" {
         // given
-        val location = Location("location", 40.7128, -74.0060)
-        val user = MuckPotUser(
-            null, "email@email.com", "pw", "nickname", Gender.MEN,
-            2000, "main", "sub", location, "url"
-        )
-        val board = Board(
-            null, user, "title", location, null,
-            LocalDateTime.now(), "content", 0, 0, 3, "link",
-            MuckPotStatus.IN_PROGRESS, 21, 23
-        )
+        val user = Fixture.createUser()
+        val board = Fixture.createBoard(user = user)
         muckPotUserRepository.save(user)
         boardRepository.save(board)
         // when

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/user/repository/MuckPotUserRepositoryTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/user/repository/MuckPotUserRepositoryTest.kt
@@ -1,26 +1,19 @@
 package com.yapp.muckpot.domains.user.repository
 
-import com.yapp.muckpot.common.Location
-import com.yapp.muckpot.common.enums.Gender
 import com.yapp.muckpot.config.CustomDataJpaTest
-import com.yapp.muckpot.domains.user.entity.MuckPotUser
+import com.yapp.muckpot.fixture.Fixture.createUser
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.annotation.Rollback
 
 @CustomDataJpaTest
-@Rollback(false)
 class MuckPotUserRepositoryTest(
     @Autowired val muckPotUserRepository: MuckPotUserRepository
 ) : StringSpec({
     "Point 타입 저장 성공" {
         // given
-        val muckPotUser = MuckPotUser(
-            null, "user@naver.com", "abcd1234", "nickname2", Gender.MEN,
-            2000, "main", "sub", Location("location", 40.7128, -74.0060), "url"
-        )
+        val muckPotUser = createUser()
         // when
         val saveUser = muckPotUserRepository.save(muckPotUser)
         // then

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/fixture/Fixture.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/fixture/Fixture.kt
@@ -1,0 +1,87 @@
+package com.yapp.muckpot.fixture
+
+import com.yapp.muckpot.common.AGE_MAX
+import com.yapp.muckpot.common.AGE_MIN
+import com.yapp.muckpot.common.Location
+import com.yapp.muckpot.common.enums.Gender
+import com.yapp.muckpot.common.enums.State
+import com.yapp.muckpot.domains.board.entity.Board
+import com.yapp.muckpot.domains.board.entity.Participant
+import com.yapp.muckpot.domains.board.entity.ParticipantId
+import com.yapp.muckpot.domains.user.entity.MuckPotUser
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus
+import java.time.LocalDateTime
+import java.util.*
+
+object Fixture {
+    fun createUser(
+        id: Long? = null,
+        email: String = UUID.randomUUID().toString().substring(0, 5) + "@naver.com",
+        password: String = "abcd1234",
+        nickName: String = UUID.randomUUID().toString(),
+        gender: Gender = Gender.MEN,
+        yearOfBirth: Int = 2000,
+        mainCategory: String = "mainCategory",
+        subCategory: String? = "subCategory",
+        location: Location = Location("userLocation", 40.7128, -74.0060),
+        imageUrl: String? = "image_url",
+        state: State = State.ACTIVE
+    ): MuckPotUser {
+        return MuckPotUser(
+            id,
+            email,
+            password,
+            nickName,
+            gender,
+            yearOfBirth,
+            mainCategory,
+            subCategory,
+            location,
+            imageUrl,
+            state
+        )
+    }
+
+    fun createBoard(
+        id: Long? = null,
+        user: MuckPotUser? = createUser(),
+        title: String = "board_title",
+        location: Location = Location("boardLocation", 40.7128, -74.0060),
+        locationDetail: String? = null,
+        meetingTime: LocalDateTime = LocalDateTime.now(),
+        content: String? = "content",
+        views: Int = 0,
+        currentApply: Int = 0,
+        maxApply: Int = 2,
+        chatLink: String = "chat_link",
+        status: MuckPotStatus = MuckPotStatus.IN_PROGRESS,
+        minAge: Int = AGE_MIN,
+        maxAge: Int = AGE_MAX,
+        state: State = State.ACTIVE
+    ): Board {
+        return Board(
+            id,
+            user,
+            title,
+            location,
+            locationDetail,
+            meetingTime,
+            content,
+            views,
+            currentApply,
+            maxApply,
+            chatLink,
+            status,
+            minAge,
+            maxAge,
+            state
+        )
+    }
+
+    fun createParticipant(
+        participantId: ParticipantId = ParticipantId(createUser(), createBoard()),
+        state: State = State.ACTIVE
+    ): Participant {
+        return Participant(participantId = participantId, state = state)
+    }
+}


### PR DESCRIPTION
## 개요
- close #43

## 작업사항
- 먹팟 조회 api 구현
- [x] 커서 기반 무한 스크룰 적용
  - [ref](https://velog.io/@minsangk/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98-Cursor-based-Pagination-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)
- [x]  정렬 조건
- 게시글: 최신순
- 참가자: 신청 선착순
- [x]  참여 멤버
- 프로필은 최대 5명, 초과 시 외N 명 **(외N명은 클릭 불 가능)**
- [x]  모집 상태
- 모집 중, 모집 마감
- [x]  시간정책, 오늘 내일 데이터
- 시간 정책
  - 60분 미만 => n분 전
  - 1시간 이상 ~ 24시간 미만 => n시간 전
  - 24시간 이상 ~ 48시간 미만 => 하루 전
  - 나머지 => YYYY년 MM월 DD일 (요일) 오전/오후 HH:MM, 썸네일에서는 YY.MM.DD
   
## 변경로직
