### PR TITLE
bug: 51 cors 설정 변경 및 로그인 유저 회원가입 및 로그인 요청 조건 수정

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
@@ -68,7 +68,7 @@ class SecurityConfig(
 
         configuration.allowedMethods = listOf("*")
         configuration.allowedHeaders = listOf("*")
-        configuration.allowedOriginPatterns = listOf("*")
+        configuration.allowedOrigins = ALLOWED_ORIGINS
         configuration.allowCredentials = true
         source.registerCorsConfiguration("/**", configuration)
         return source
@@ -94,6 +94,10 @@ class SecurityConfig(
             EMAIL_REQUEST,
             EMAIL_VERIFY,
             USER_PROFILE_URL
+        )
+
+        val ALLOWED_ORIGINS = listOf(
+            "http://localhost:3000"
         )
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
@@ -66,9 +66,9 @@ class SecurityConfig(
         val configuration = CorsConfiguration()
         val source = UrlBasedCorsConfigurationSource()
 
-        configuration.allowedOrigins = listOf("*")
         configuration.allowedMethods = listOf("*")
         configuration.allowedHeaders = listOf("*")
+        configuration.allowedOriginPatterns = listOf("*")
         configuration.allowCredentials = true
         source.registerCorsConfiguration("/**", configuration)
         return source

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
@@ -1,6 +1,5 @@
 package com.yapp.muckpot.filter
 
-import com.yapp.muckpot.common.LOGIN_URL
 import com.yapp.muckpot.common.ResponseWriter
 import com.yapp.muckpot.common.security.AuthenticationUser
 import com.yapp.muckpot.config.SecurityConfig.Companion.POST_PERMIT_ALL_URLS
@@ -20,7 +19,7 @@ class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerReques
         filterChain: FilterChain
     ) {
         jwtService.getCurrentUserClaim()?.let {
-            if (POST_PERMIT_ALL_URLS.contains(request.requestURI.equals(LOGIN_URL).toString())) {
+            if (POST_PERMIT_ALL_URLS.contains(request.requestURI.toString())) {
                 ResponseWriter.writeResponse(response, HttpStatus.BAD_REQUEST, "이미 로그인한 유저 입니다.")
                 return
             }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
@@ -1,8 +1,9 @@
 package com.yapp.muckpot.filter
 
+import com.yapp.muckpot.common.LOGIN_URL
 import com.yapp.muckpot.common.ResponseWriter
+import com.yapp.muckpot.common.SIGN_UP_URL
 import com.yapp.muckpot.common.security.AuthenticationUser
-import com.yapp.muckpot.config.SecurityConfig.Companion.POST_PERMIT_ALL_URLS
 import com.yapp.muckpot.domains.user.service.JwtService
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -19,7 +20,8 @@ class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerReques
         filterChain: FilterChain
     ) {
         jwtService.getCurrentUserClaim()?.let {
-            if (POST_PERMIT_ALL_URLS.contains(request.requestURI.toString())) {
+            val requestURI = request.requestURI.toString()
+            if (LOGIN_URL == requestURI || SIGN_UP_URL == requestURI) {
                 ResponseWriter.writeResponse(response, HttpStatus.BAD_REQUEST, "이미 로그인한 유저 입니다.")
                 return
             }


### PR DESCRIPTION
## 개요
- close #51

## 작업사항
- cors 설정 변경
- 우선, 기존설정만 변경해보았습니다. 배포 후 안되면 FE 환경 구축하여 다시 테스트 해보겠숩니다..

## 변경로직
- allowedOrigins -> allowedOriginPatterns 변경
  - allowedOrigins에 * 값을 포함하는 경우 allowCredentials가 true로 설정되어 있더라도 CORS 정책을 준수할 수 없다고 함.
- 로그인한 유저가 다시 로그인, 회원가입하지못하는 로직 조건 같이 수정하였습니다 !