### PR TITLE
feat: 50 먹팟 상세조회 구현

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SecurityContextHolderUtil.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SecurityContextHolderUtil.kt
@@ -1,0 +1,20 @@
+package com.yapp.muckpot.common
+
+import com.yapp.muckpot.domains.user.controller.dto.UserResponse
+import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+
+object SecurityContextHolderUtil {
+    /**
+     * SecurityContextHolder 에서 credential 을 가져온다.
+     *
+     * credential 정보
+     * @see com.yapp.muckpot.common.security.AuthenticationUser
+     */
+    fun getCredentialOrNull(): UserResponse? {
+        if (SecurityContextHolder.getContext().authentication is AnonymousAuthenticationToken) {
+            return null
+        }
+        return SecurityContextHolder.getContext().authentication.credentials as UserResponse
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
@@ -104,7 +104,6 @@ const val MUCKPOT_FIND_BY_ID = """
     "views": 1,
     "participants": [
       {
-        "boardId": 114,
         "userId": 128,
         "nickName": "nickname2",
         "jobGroupMain": "개발",

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/SwaggerConstant.kt
@@ -1,5 +1,6 @@
 package com.yapp.muckpot.swagger
 
+// User
 const val TEST_SAMPLE = """
 {
   "id": 1,
@@ -33,6 +34,17 @@ const val EMAIL_AUTH_RESPONSE = """
 }
 """
 
+const val SIGN_UP_RESPONSE = """
+{
+    "status": 201,
+    "result": {
+        "userId": 1,
+        "nickName": "nickName"
+    }
+}
+"""
+
+// Board
 const val MUCKPOT_SAVE_RESPONSE = """
 {
   "status": 201,
@@ -69,12 +81,36 @@ const val MUCKPOT_FIND_ALL = """
 }
 """
 
-const val SIGN_UP_RESPONSE = """
+const val MUCKPOT_FIND_BY_ID = """
 {
-    "status": 201,
-    "result": {
-        "userId": 1,
-        "nickName": "nickName"
-    }
+  "status": 200,
+  "result": {
+    "boardId": 114,
+    "title": "같이 밥묵으실분",
+    "content": "내용 입니다.",
+    "chatLink": "https://open.kakao.com/o/gSIkvvHc",
+    "status": "모집중",
+    "meetingDate": "07월 21일 (금)",
+    "meetingTime": "오후 01:00",
+    "createDate": "2023년 06월 11일",
+    "maxApply": 5,
+    "currentApply": 1,
+    "minAge": 20,
+    "maxAge": 100,
+    "locationName": "서울 성북구 안암동5가 104-30 캐치카페 안암",
+    "x": 127.02970799701643,
+    "y": 37.58392327180857,
+    "locationDetail": "6층",
+    "views": 1,
+    "participants": [
+      {
+        "boardId": 114,
+        "userId": 128,
+        "nickName": "nickname2",
+        "jobGroupMain": "개발",
+        "writer": true
+      }
+    ]
+  }
 }
 """

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
@@ -68,7 +68,7 @@ class SecurityConfig(
 
         configuration.allowedMethods = listOf("*")
         configuration.allowedHeaders = listOf("*")
-        configuration.allowedOriginPatterns = listOf("*")
+        configuration.allowedOrigins = ALLOWED_ORIGINS
         configuration.allowCredentials = true
         source.registerCorsConfiguration("/**", configuration)
         return source
@@ -94,6 +94,10 @@ class SecurityConfig(
             EMAIL_REQUEST,
             EMAIL_VERIFY,
             USER_PROFILE_URL
+        )
+
+        val ALLOWED_ORIGINS = listOf(
+            "http://localhost:3000"
         )
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/config/SecurityConfig.kt
@@ -66,9 +66,9 @@ class SecurityConfig(
         val configuration = CorsConfiguration()
         val source = UrlBasedCorsConfigurationSource()
 
-        configuration.allowedOrigins = listOf("*")
         configuration.allowedMethods = listOf("*")
         configuration.allowedHeaders = listOf("*")
+        configuration.allowedOriginPatterns = listOf("*")
         configuration.allowCredentials = true
         source.registerCorsConfiguration("/**", configuration)
         return source

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
@@ -2,11 +2,13 @@ package com.yapp.muckpot.domains.board.controller
 
 import com.yapp.muckpot.common.ResponseDto
 import com.yapp.muckpot.common.ResponseEntityUtil
+import com.yapp.muckpot.common.SecurityContextHolderUtil
 import com.yapp.muckpot.common.dto.CursorPaginationRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateResponse
 import com.yapp.muckpot.domains.board.service.BoardService
 import com.yapp.muckpot.swagger.MUCKPOT_FIND_ALL
+import com.yapp.muckpot.swagger.MUCKPOT_FIND_BY_ID
 import com.yapp.muckpot.swagger.MUCKPOT_SAVE_RESPONSE
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
@@ -19,6 +21,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -77,5 +80,30 @@ class BoardController(
     @GetMapping("/v1/boards")
     fun findAll(@ModelAttribute request: CursorPaginationRequest): ResponseEntity<ResponseDto> {
         return ResponseEntityUtil.ok(boardService.findAllMuckpot(request))
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 200,
+                examples = Example(
+                    ExampleProperty(
+                        value = MUCKPOT_FIND_BY_ID,
+                        mediaType = MediaType.APPLICATION_JSON_VALUE
+                    )
+                ),
+                message = "성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "먹팟 글 상세 조회")
+    @GetMapping("/v1/boards/{boardId}")
+    fun findByBoardId(@PathVariable boardId: Long): ResponseEntity<ResponseDto> {
+        return ResponseEntityUtil.ok(
+            boardService.findBoardDetailAndVisit(
+                boardId,
+                SecurityContextHolderUtil.getCredentialOrNull()
+            )
+        )
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
@@ -9,7 +9,7 @@ import com.yapp.muckpot.domains.board.entity.Board
 import com.yapp.muckpot.domains.user.controller.dto.UserResponse
 
 data class MuckpotDetailResponse(
-    val boardId: Long?,
+    val boardId: Long,
     val title: String,
     val content: String? = null,
     val chatLink: String,
@@ -34,7 +34,7 @@ data class MuckpotDetailResponse(
         }
     }
 
-    fun sortParticipantsIfLoginUserParticipant(loginUserInfo: UserResponse?) {
+    fun sortParticipantsByLoginUser(loginUserInfo: UserResponse?) {
         if (participants.size > 1) {
             loginUserInfo?.let { userInfo ->
                 val mutableParticipants = participants.toMutableList()
@@ -50,7 +50,7 @@ data class MuckpotDetailResponse(
     companion object {
         fun of(board: Board, participants: List<ParticipantReadResponse>): MuckpotDetailResponse {
             return MuckpotDetailResponse(
-                boardId = board.id,
+                boardId = board.id ?: 0,
                 title = board.title,
                 content = board.content,
                 chatLink = board.chatLink,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponse.kt
@@ -1,0 +1,74 @@
+package com.yapp.muckpot.domains.board.controller.dto
+
+import com.yapp.muckpot.common.KR_MM_DD_E
+import com.yapp.muckpot.common.KR_YYYY_MM_DD
+import com.yapp.muckpot.common.TimeUtil
+import com.yapp.muckpot.common.a_hhmm
+import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
+import com.yapp.muckpot.domains.board.entity.Board
+import com.yapp.muckpot.domains.user.controller.dto.UserResponse
+
+data class MuckpotDetailResponse(
+    val boardId: Long?,
+    val title: String,
+    val content: String? = null,
+    val chatLink: String,
+    val status: String,
+    val meetingDate: String,
+    val meetingTime: String,
+    val createDate: String,
+    val maxApply: Int,
+    val currentApply: Int,
+    val minAge: Int,
+    val maxAge: Int,
+    val locationName: String,
+    val x: Double,
+    val y: Double,
+    val locationDetail: String? = null,
+    val views: Int,
+    var participants: List<ParticipantReadResponse>
+) {
+    init {
+        if (participants.isNotEmpty()) {
+            participants.first().writer = true
+        }
+    }
+
+    fun sortParticipantsIfLoginUserParticipant(loginUserInfo: UserResponse?) {
+        if (participants.size > 1) {
+            loginUserInfo?.let { userInfo ->
+                val mutableParticipants = participants.toMutableList()
+                val myParticipantIndex = mutableParticipants.indexOfFirst { it.userId == userInfo.userId }
+                if (myParticipantIndex != -1) {
+                    val participant = mutableParticipants.removeAt(myParticipantIndex)
+                    participants = listOf(participant) + mutableParticipants
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun of(board: Board, participants: List<ParticipantReadResponse>): MuckpotDetailResponse {
+            return MuckpotDetailResponse(
+                boardId = board.id,
+                title = board.title,
+                content = board.content,
+                chatLink = board.chatLink,
+                status = board.status.korNm,
+                meetingDate = TimeUtil.localeKoreanFormatting(board.meetingTime, KR_MM_DD_E),
+                meetingTime = TimeUtil.localeKoreanFormatting(board.meetingTime, a_hhmm),
+                createDate = TimeUtil.localeKoreanFormatting(board.createdAt, KR_YYYY_MM_DD),
+                maxApply = board.maxApply,
+                currentApply = board.currentApply,
+                minAge = board.minAge,
+                maxAge = board.maxAge,
+                locationName = board.location.locationName,
+                x = board.getX(),
+                y = board.getY(),
+                locationDetail = board.locationDetail,
+                views = board.views,
+                participants = participants
+            )
+        }
+    }
+}

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotReadResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotReadResponse.kt
@@ -8,7 +8,7 @@ import com.yapp.muckpot.domains.board.entity.Board
 import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 
 data class MuckpotReadResponse(
-    val boardId: Long?,
+    val boardId: Long,
     val title: String,
     val status: String,
     val todayOrTomorrow: String?,
@@ -40,7 +40,7 @@ data class MuckpotReadResponse(
                 status = MuckPotStatus.DONE.korNm
             }
             return MuckpotReadResponse(
-                boardId = board.id,
+                boardId = board.id ?: 0,
                 title = board.title,
                 status = status,
                 todayOrTomorrow = TimeUtil.isTodayOrTomorrow(board.createdAt.toLocalDate()),

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotReadResponse.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotReadResponse.kt
@@ -1,6 +1,8 @@
 package com.yapp.muckpot.domains.board.controller.dto
 
+import com.yapp.muckpot.common.KR_MM_DD_E
 import com.yapp.muckpot.common.TimeUtil
+import com.yapp.muckpot.common.a_hhmm
 import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
 import com.yapp.muckpot.domains.board.entity.Board
 import com.yapp.muckpot.domains.user.enums.MuckPotStatus
@@ -11,7 +13,7 @@ data class MuckpotReadResponse(
     val status: String,
     val todayOrTomorrow: String?,
     val elapsedTime: String,
-    val meetingTime: String,
+    val meetingDateTime: String,
     val meetingPlace: String,
     val maxApply: Int,
     val currentApply: Int,
@@ -33,9 +35,9 @@ data class MuckpotReadResponse(
 
         fun of(board: Board, participants: List<ParticipantReadResponse>): MuckpotReadResponse {
             // TODO 만료 된 먹팟 종료 처리 후, 해당 로직은 제거.
-            var status = board.status.krNm
+            var status = board.status.korNm
             if (board.expired()) {
-                status = MuckPotStatus.DONE.krNm
+                status = MuckPotStatus.DONE.korNm
             }
             return MuckpotReadResponse(
                 boardId = board.id,
@@ -43,7 +45,7 @@ data class MuckpotReadResponse(
                 status = status,
                 todayOrTomorrow = TimeUtil.isTodayOrTomorrow(board.createdAt.toLocalDate()),
                 elapsedTime = TimeUtil.formatElapsedTime(board.createdAt),
-                meetingTime = TimeUtil.formatMeetingTime(board.meetingTime),
+                meetingDateTime = TimeUtil.localeKoreanFormatting(board.meetingTime, "$KR_MM_DD_E $a_hhmm"),
                 meetingPlace = board.location.locationName,
                 maxApply = board.maxApply,
                 currentApply = board.currentApply,

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -54,7 +54,7 @@ class BoardService(
         boardRepository.findByIdOrNull(boardId)?.let {
             it.visit()
             return MuckpotDetailResponse.of(it, participantQuerydslRepository.findByBoardIds(listOf(boardId))).apply {
-                sortParticipantsIfLoginUserParticipant(loginUserInfo)
+                sortParticipantsByLoginUser(loginUserInfo)
             }
         } ?: run {
             throw MuckPotException(BoardErrorCode.BOARD_NOT_FOUND)

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -3,12 +3,15 @@ package com.yapp.muckpot.domains.board.service
 import com.yapp.muckpot.common.dto.CursorPaginationRequest
 import com.yapp.muckpot.common.dto.CursorPaginationResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
+import com.yapp.muckpot.domains.board.controller.dto.MuckpotDetailResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotReadResponse
 import com.yapp.muckpot.domains.board.entity.Participant
+import com.yapp.muckpot.domains.board.exception.BoardErrorCode
 import com.yapp.muckpot.domains.board.repository.BoardQuerydslRepository
 import com.yapp.muckpot.domains.board.repository.BoardRepository
 import com.yapp.muckpot.domains.board.repository.ParticipantQuerydslRepository
 import com.yapp.muckpot.domains.board.repository.ParticipantRepository
+import com.yapp.muckpot.domains.user.controller.dto.UserResponse
 import com.yapp.muckpot.domains.user.exception.UserErrorCode
 import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
 import com.yapp.muckpot.exception.MuckPotException
@@ -44,5 +47,17 @@ class BoardService(
             return CursorPaginationResponse(responseList, responseList.last().boardId)
         }
         return CursorPaginationResponse(responseList)
+    }
+
+    @Transactional
+    fun findBoardDetailAndVisit(boardId: Long, loginUserInfo: UserResponse?): MuckpotDetailResponse {
+        boardRepository.findByIdOrNull(boardId)?.let {
+            it.visit()
+            return MuckpotDetailResponse.of(it, participantQuerydslRepository.findByBoardIds(listOf(boardId))).apply {
+                sortParticipantsIfLoginUserParticipant(loginUserInfo)
+            }
+        } ?: run {
+            throw MuckPotException(BoardErrorCode.BOARD_NOT_FOUND)
+        }
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/UserController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/controller/UserController.kt
@@ -2,6 +2,7 @@ package com.yapp.muckpot.domains.user.controller
 
 import com.yapp.muckpot.common.ResponseDto
 import com.yapp.muckpot.common.ResponseEntityUtil
+import com.yapp.muckpot.common.SecurityContextHolderUtil
 import com.yapp.muckpot.domains.user.controller.dto.LoginRequest
 import com.yapp.muckpot.domains.user.controller.dto.SendEmailAuthRequest
 import com.yapp.muckpot.domains.user.controller.dto.SignUpRequest
@@ -124,7 +125,7 @@ class UserController(
     @ApiOperation(value = "유저 프로필 조회")
     @GetMapping("/v1/users/profile")
     fun findLoginUserProfile(): ResponseEntity<ResponseDto> {
-        return userService.findLoginUserProfile()?.let {
+        return SecurityContextHolderUtil.getCredentialOrNull()?.let {
             ResponseEntityUtil.ok(it)
         } ?: run {
             ResponseEntityUtil.noContent()

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
@@ -55,8 +55,7 @@ class JwtService(
             val decodedJwt = verify(JwtCookieUtil.getAccessToken())
             objectMapper.readValue(decodedJwt.getClaim(USER_CLAIM).asString(), UserResponse::class.java)
         } catch (exception: Exception) {
-            log.debug(exception) { "" }
-            log.info { "로그인 유저 정보를 찾을 수 없습니다." }
+            log.debug(exception) { "로그인 유저 정보를 찾을 수 없습니다."  }
             null
         }
     }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/JwtService.kt
@@ -55,7 +55,7 @@ class JwtService(
             val decodedJwt = verify(JwtCookieUtil.getAccessToken())
             objectMapper.readValue(decodedJwt.getClaim(USER_CLAIM).asString(), UserResponse::class.java)
         } catch (exception: Exception) {
-            log.debug(exception) { "로그인 유저 정보를 찾을 수 없습니다."  }
+            log.debug(exception) { "로그인 유저 정보를 찾을 수 없습니다." }
             null
         }
     }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/UserService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/UserService.kt
@@ -66,10 +66,6 @@ class UserService(
         }
     }
 
-    fun findLoginUserProfile(): UserResponse? {
-        return jwtService.getCurrentUserClaim()
-    }
-
     @Transactional
     fun signUp(request: SignUpRequest): UserResponse {
         userRepository.findByEmail(request.email)?.let {

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
@@ -1,6 +1,5 @@
 package com.yapp.muckpot.filter
 
-import com.yapp.muckpot.common.LOGIN_URL
 import com.yapp.muckpot.common.ResponseWriter
 import com.yapp.muckpot.common.security.AuthenticationUser
 import com.yapp.muckpot.config.SecurityConfig.Companion.POST_PERMIT_ALL_URLS
@@ -20,7 +19,7 @@ class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerReques
         filterChain: FilterChain
     ) {
         jwtService.getCurrentUserClaim()?.let {
-            if (POST_PERMIT_ALL_URLS.contains(request.requestURI.equals(LOGIN_URL).toString())) {
+            if (POST_PERMIT_ALL_URLS.contains(request.requestURI.toString())) {
                 ResponseWriter.writeResponse(response, HttpStatus.BAD_REQUEST, "이미 로그인한 유저 입니다.")
                 return
             }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/filter/JwtAuthorizationFilter.kt
@@ -1,8 +1,9 @@
 package com.yapp.muckpot.filter
 
+import com.yapp.muckpot.common.LOGIN_URL
 import com.yapp.muckpot.common.ResponseWriter
+import com.yapp.muckpot.common.SIGN_UP_URL
 import com.yapp.muckpot.common.security.AuthenticationUser
-import com.yapp.muckpot.config.SecurityConfig.Companion.POST_PERMIT_ALL_URLS
 import com.yapp.muckpot.domains.user.service.JwtService
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -19,7 +20,8 @@ class JwtAuthorizationFilter(private val jwtService: JwtService) : OncePerReques
         filterChain: FilterChain
     ) {
         jwtService.getCurrentUserClaim()?.let {
-            if (POST_PERMIT_ALL_URLS.contains(request.requestURI.toString())) {
+            val requestURI = request.requestURI.toString()
+            if (LOGIN_URL == requestURI || SIGN_UP_URL == requestURI) {
                 ResponseWriter.writeResponse(response, HttpStatus.BAD_REQUEST, "이미 로그인한 유저 입니다.")
                 return
             }

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/common/TimeUtilTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/common/TimeUtilTest.kt
@@ -76,7 +76,7 @@ class TimeUtilTest : FunSpec({
         }
     }
 
-    context("formatMeetingTime 테스트") {
+    context("a_hhmm 포 테스트") {
         withData(
             nameFn = { "${it.a}:${it.b}" },
             row(0, 0, "오전"),
@@ -87,7 +87,21 @@ class TimeUtilTest : FunSpec({
             // given
             val localDateTime = LocalDateTime.of(2023, 1, 1, hour, minute)
             // when & then
-            TimeUtil.formatMeetingTime(localDateTime) shouldContain amPm
+            TimeUtil.localeKoreanFormatting(localDateTime, a_hhmm) shouldContain amPm
         }
+    }
+
+    test("KR_MM_DD_E 포맷 테스트") {
+        // given
+        val localDateTime = LocalDateTime.of(2020, 1, 2, 12, 0)
+        // when & then
+        TimeUtil.localeKoreanFormatting(localDateTime, KR_MM_DD_E) shouldBe "01월 02일 (목)"
+    }
+
+    test("KR_YYYY_MM_DD 포맷 테스트") {
+        // given
+        val localDateTime = LocalDateTime.of(2020, 1, 2, 12, 0)
+        // when & then
+        TimeUtil.localeKoreanFormatting(localDateTime, KR_YYYY_MM_DD) shouldBe "2020년 01월 02일"
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponseTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponseTest.kt
@@ -1,0 +1,39 @@
+package com.yapp.muckpot.domains.board.controller.dto
+
+import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
+import com.yapp.muckpot.domains.user.controller.dto.UserResponse
+import com.yapp.muckpot.domains.user.enums.JobGroupMain
+import com.yapp.muckpot.fixture.Fixture
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class MuckpotDetailResponseTest : StringSpec({
+    "로그인 유저가 참여했다면 가장 첫번째로 정렬된다." {
+        // given
+        val loginUser = UserResponse(2, "user2")
+        val participants = listOf(
+            ParticipantReadResponse(1, 1, "user1", JobGroupMain.DEVELOPMENT),
+            ParticipantReadResponse(1, loginUser.userId, loginUser.nickName, JobGroupMain.DEVELOPMENT),
+            ParticipantReadResponse(1, 3, "user3", JobGroupMain.DEVELOPMENT)
+        )
+        val response = MuckpotDetailResponse.of(Fixture.createBoard(), participants)
+        // when
+        response.sortParticipantsIfLoginUserParticipant(loginUser)
+        // then
+        response.participants[0].userId shouldBe loginUser.userId
+        response.participants[0].nickName shouldBe loginUser.nickName
+    }
+
+    "가장 첫번째 참여한 인원이 조직장이 된다." {
+        // given
+        val participants = listOf(
+            ParticipantReadResponse(1, 1, "user1", JobGroupMain.DEVELOPMENT),
+            ParticipantReadResponse(1, 2, "user2", JobGroupMain.DEVELOPMENT),
+            ParticipantReadResponse(1, 3, "user3", JobGroupMain.DEVELOPMENT)
+        )
+        // when
+        val response = MuckpotDetailResponse.of(Fixture.createBoard(), participants)
+        // then
+        response.participants[0].writer shouldBe true
+    }
+})

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponseTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotDetailResponseTest.kt
@@ -18,7 +18,7 @@ class MuckpotDetailResponseTest : StringSpec({
         )
         val response = MuckpotDetailResponse.of(Fixture.createBoard(), participants)
         // when
-        response.sortParticipantsIfLoginUserParticipant(loginUser)
+        response.sortParticipantsByLoginUser(loginUser)
         // then
         response.participants[0].userId shouldBe loginUser.userId
         response.participants[0].nickName shouldBe loginUser.nickName

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
@@ -1,18 +1,23 @@
 package com.yapp.muckpot.domains.board.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import com.yapp.muckpot.common.dto.CursorPaginationRequest
 import com.yapp.muckpot.domains.board.dto.ParticipantReadResponse
 import com.yapp.muckpot.domains.board.repository.BoardQuerydslRepository
+import com.yapp.muckpot.domains.board.repository.BoardRepository
 import com.yapp.muckpot.domains.board.repository.ParticipantQuerydslRepository
+import com.yapp.muckpot.domains.user.controller.dto.UserResponse
 import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 import com.yapp.muckpot.fixture.Fixture
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
 
 @SpringBootTest
 class BoardServiceMockTest @Autowired constructor(
@@ -20,54 +25,90 @@ class BoardServiceMockTest @Autowired constructor(
     @MockkBean
     private val boardQuerydslRepository: BoardQuerydslRepository,
     @MockkBean
-    private val participantQuerydslRepository: ParticipantQuerydslRepository
-) : StringSpec({
-    val allBoardSize = 3
+    private val participantQuerydslRepository: ParticipantQuerydslRepository,
+    @MockkBean
+    private val boardRepository: BoardRepository
+) : FunSpec({
+    context("findAllMuckpot 테스트") {
+        val allBoardSize = 3
+        val allBoard = listOf(
+            Fixture.createBoard(id = 1, title = "board1"),
+            Fixture.createBoard(id = 2, title = "board2"),
+            Fixture.createBoard(id = 3, title = "board3")
+        )
+        val participantResponses = listOf(
+            ParticipantReadResponse(boardId = 1, userId = 1, nickName = "user1"),
+            ParticipantReadResponse(boardId = 1, userId = 2, nickName = "user2"),
+            ParticipantReadResponse(boardId = 1, userId = 3, nickName = "user3"),
+            ParticipantReadResponse(boardId = 1, userId = 4, nickName = "user4"),
+            ParticipantReadResponse(boardId = 1, userId = 5, nickName = "user5"),
+            ParticipantReadResponse(boardId = 1, userId = 6, nickName = "user6"),
+            ParticipantReadResponse(boardId = 1, userId = 7, nickName = "user7"),
+            ParticipantReadResponse(boardId = 1, userId = 8, nickName = "user8"),
+            ParticipantReadResponse(boardId = 2, userId = 1, nickName = "user1"),
+            ParticipantReadResponse(boardId = 2, userId = 2, nickName = "user2"),
+            ParticipantReadResponse(boardId = 3, userId = 1, nickName = "user1")
+        )
+        beforeTest {
+            // given
+            every { boardQuerydslRepository.findAllWithPagination(any(), any()) } returns allBoard
+            every { participantQuerydslRepository.findByBoardIds(any()) } returns participantResponses
+        }
+        test("모든 먹팟 조회 성공") {
+            // when
+            val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
+            // then
+            actual.list shouldHaveSize 3
+            actual.lastId shouldBe allBoard.last().id
+        }
 
-    val allBoard = listOf(
-        Fixture.createBoard(id = 1, title = "board1"),
-        Fixture.createBoard(id = 2, title = "board2"),
-        Fixture.createBoard(id = 3, title = "board3")
-    )
-    val participantResponses = listOf(
-        ParticipantReadResponse(boardId = 1, userId = 1, nickName = "user1"),
-        ParticipantReadResponse(boardId = 1, userId = 2, nickName = "user2"),
-        ParticipantReadResponse(boardId = 1, userId = 3, nickName = "user3"),
-        ParticipantReadResponse(boardId = 1, userId = 4, nickName = "user4"),
-        ParticipantReadResponse(boardId = 1, userId = 5, nickName = "user5"),
-        ParticipantReadResponse(boardId = 1, userId = 6, nickName = "user6"),
-        ParticipantReadResponse(boardId = 1, userId = 7, nickName = "user7"),
-        ParticipantReadResponse(boardId = 1, userId = 8, nickName = "user8"),
-        ParticipantReadResponse(boardId = 2, userId = 1, nickName = "user1"),
-        ParticipantReadResponse(boardId = 2, userId = 2, nickName = "user2"),
-        ParticipantReadResponse(boardId = 3, userId = 1, nickName = "user1")
-    )
+        test("참가자가 6명을 넘어가면 마지막에 외N 명으로 응답한다") {
+            // when
+            val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
+            // then
+            actual.list[0].participants.last().nickName shouldBe "외 3명"
+        }
 
-    beforeTest {
-        // given
-        every { boardQuerydslRepository.findAllWithPagination(any(), any()) } returns allBoard
-        every { participantQuerydslRepository.findByBoardIds(any()) } returns participantResponses
+        test("현재 시간 이전인 경우 모집마감 으로 바꾸어 응답한다.") {
+            // when
+            val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
+            // then
+            actual.list[0].status shouldBe MuckPotStatus.DONE.korNm
+        }
     }
 
-    "모든 먹팟 조회 성공" {
-        // when
-        val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
-        // then
-        actual.list shouldHaveSize 3
-        actual.lastId shouldBe allBoard.last().id
-    }
+    context("findBoardDetailAndVisit 성공") {
+        val loginUser = UserResponse(2, "user2")
+        val board = Fixture.createBoard(
+            id = 1,
+            title = "board1",
+            meetingTime = LocalDateTime.of(2020, 12, 25, 12, 20, 30)
+        ).apply {
+            createdAt = LocalDateTime.of(2020, 12, 23, 12, 20, 30)
+        }
+        val participantResponses = listOf(
+            ParticipantReadResponse(boardId = 1, userId = 1, nickName = "user1"),
+            ParticipantReadResponse(boardId = 1, userId = 2, nickName = "user2"),
+            ParticipantReadResponse(boardId = 1, userId = 3, nickName = "user3")
+        )
+        beforeTest {
+            // given
+            every { boardRepository.findByIdOrNull(any()) } returns board
+            every { participantQuerydslRepository.findByBoardIds(any()) } returns participantResponses
+        }
 
-    "참가자가 6명을 넘어가면 마지막에 외N 명으로 응답한다" {
-        // when
-        val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
-        // then
-        actual.list[0].participants.last().nickName shouldBe "외 3명"
-    }
+        test("먹팟 상세조회 성공") {
+            // when
+            val actual = boardService.findBoardDetailAndVisit(1, loginUser)
 
-    "현재 시간 이전인 경우 모집마감 으로 바꾸어 응답한다." {
-        // when
-        val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
-        // then
-        actual.list[0].status shouldBe MuckPotStatus.DONE.korNm
+            val result = ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(actual)
+            println(result)
+            // then
+            actual.meetingDate shouldBe "12월 25일 (금)"
+            actual.meetingTime shouldBe "오후 12:20"
+            actual.createDate shouldBe "2020년 12월 23일"
+            actual.status shouldBe MuckPotStatus.IN_PROGRESS.korNm
+            actual.participants shouldHaveSize participantResponses.size
+        }
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceMockTest.kt
@@ -68,6 +68,6 @@ class BoardServiceMockTest @Autowired constructor(
         // when
         val actual = boardService.findAllMuckpot(CursorPaginationRequest(null, allBoardSize.toLong()))
         // then
-        actual.list[0].status shouldBe MuckPotStatus.DONE.krNm
+        actual.list[0].status shouldBe MuckPotStatus.DONE.korNm
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -6,6 +6,7 @@ import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.entity.ParticipantId
 import com.yapp.muckpot.domains.board.repository.BoardRepository
 import com.yapp.muckpot.domains.board.repository.ParticipantRepository
+import com.yapp.muckpot.domains.user.controller.dto.UserResponse
 import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import com.yapp.muckpot.domains.user.enums.JobGroupMain
 import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
@@ -70,5 +71,19 @@ class BoardServiceTest @Autowired constructor(
         findBoard.user?.id shouldBe userId
         findBoard.currentApply shouldBe 1
         participant shouldNotBe null
+    }
+
+    "먹팟 상세 조회시 조회수가 증가한다." {
+        // given
+        val boardId = boardService.saveBoard(userId, request)!!
+        val loginUserInfo = UserResponse.of(user)
+
+        // when
+        boardService.findBoardDetailAndVisit(boardId, loginUserInfo)
+        boardService.findBoardDetailAndVisit(boardId, loginUserInfo)
+
+        // then
+        val findBoard = boardRepository.findByIdOrNull(boardId)!!
+        findBoard.views shouldBe 2
     }
 })

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/Location.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/Location.kt
@@ -12,7 +12,7 @@ class Location(
     var locationName: String,
 
     @Column(name = "location_point", columnDefinition = "Point")
-    val locationPoint: Point? = null
+    val locationPoint: Point
 ) {
     constructor(locationName: String, x: Double, y: Double) : this(
         locationName,

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/RegexPatternConst.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/RegexPatternConst.kt
@@ -6,3 +6,7 @@ const val PW_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}\$"
 const val ONLY_NAVER = "^[A-Za-z0-9._%+-]+@naver\\.com\$"
 const val YYYYMMDD = "yyyy-MM-dd"
 const val HHmm = "HH:mm"
+
+const val KR_MM_DD_E = "MM월 dd일 (E)"
+const val KR_YYYY_MM_DD = "YYYY년 MM월 dd일"
+const val a_hhmm = "a hh:mm"

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeConstant.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeConstant.kt
@@ -11,5 +11,3 @@ const val MINUTES_IN_TWO_DAY = 2880
 const val N_MINUTES_AGO = "%d분 전"
 const val N_HOURS_AGO = "%d시간 전"
 const val A_DAY_AGO = "하루 전"
-
-const val MEETING_TIME_PATTERN = "MM월 dd일 (E) a hh:mm"

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeUtil.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/TimeUtil.kt
@@ -37,8 +37,8 @@ object TimeUtil {
         }
     }
 
-    fun formatMeetingTime(localDateTime: LocalDateTime): String {
-        val formatter = DateTimeFormatter.ofPattern(MEETING_TIME_PATTERN, Locale.KOREAN)
+    fun localeKoreanFormatting(localDateTime: LocalDateTime, pattern: String): String {
+        val formatter = DateTimeFormatter.ofPattern(pattern, Locale.KOREAN)
         return localDateTime.format(formatter)
     }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/dto/ParticipantReadResponse.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/dto/ParticipantReadResponse.kt
@@ -1,24 +1,26 @@
 package com.yapp.muckpot.domains.board.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.querydsl.core.annotations.QueryProjection
 import com.yapp.muckpot.domains.user.enums.JobGroupMain
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ParticipantReadResponse constructor(
+    @JsonIgnore
     val boardId: Long? = null,
     val userId: Long?,
     val nickName: String,
-    val jonGroupMain: JobGroupMain? = null,
-    var isWriter: Boolean? = null
+    val jobGroupMain: String? = null,
+    var writer: Boolean? = null
 ) {
     @QueryProjection
     constructor(
         boardId: Long?,
         userId: Long?,
         nickName: String,
-        jonGroupMain: JobGroupMain?
-    ) : this(boardId, userId, nickName, jonGroupMain, null)
+        jobGroupMain: JobGroupMain
+    ) : this(boardId, userId, nickName, jobGroupMain.korName, null)
 
     companion object {
         fun otherN(otherCnt: Int): ParticipantReadResponse {

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/dto/ParticipantReadResponse.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/dto/ParticipantReadResponse.kt
@@ -1,14 +1,25 @@
 package com.yapp.muckpot.domains.board.dto
 
-import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.querydsl.core.annotations.QueryProjection
+import com.yapp.muckpot.domains.user.enums.JobGroupMain
 
-data class ParticipantReadResponse @QueryProjection constructor(
-    @JsonIgnore
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ParticipantReadResponse constructor(
     val boardId: Long? = null,
     val userId: Long?,
-    val nickName: String
+    val nickName: String,
+    val jonGroupMain: JobGroupMain? = null,
+    var isWriter: Boolean? = null
 ) {
+    @QueryProjection
+    constructor(
+        boardId: Long?,
+        userId: Long?,
+        nickName: String,
+        jonGroupMain: JobGroupMain?
+    ) : this(boardId, userId, nickName, jonGroupMain, null)
+
     companion object {
         fun otherN(otherCnt: Int): ParticipantReadResponse {
             return ParticipantReadResponse(

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -91,7 +91,19 @@ class Board(
         }
     }
 
+    fun visit() {
+        this.views++
+    }
+
     fun expired(): Boolean {
         return (this.status == MuckPotStatus.IN_PROGRESS && this.meetingTime.isBefore(LocalDateTime.now()))
+    }
+
+    fun getX(): Double {
+        return this.location.locationPoint.x
+    }
+
+    fun getY(): Double {
+        return this.location.locationPoint.y
     }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/exception/BoardErrorCode.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/exception/BoardErrorCode.kt
@@ -8,7 +8,7 @@ enum class BoardErrorCode(
     private val status: Int,
     private val reason: String
 ) : BaseErrorCode {
-    BOARD_NOT_FOUND(StatusCode.BAD_REQUEST.code, "보드를 찾을 수 없습니다.");
+    BOARD_NOT_FOUND(StatusCode.BAD_REQUEST.code, "먹팟 정보를 찾을 수 없습니다.");
 
     override fun toResponseDto(): ResponseDto {
         return ResponseDto(this.status, this.reason, null)

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantQuerydslRepository.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/repository/ParticipantQuerydslRepository.kt
@@ -15,7 +15,8 @@ class ParticipantQuerydslRepository(
             QParticipantReadResponse(
                 participant.participantId.board.id,
                 participant.participantId.user.id,
-                participant.participantId.user.nickName
+                participant.participantId.user.nickName,
+                participant.participantId.user.mainCategory
             )
         )
             .from(participant)

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/enums/MuckPotStatus.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/user/enums/MuckPotStatus.kt
@@ -1,7 +1,7 @@
 package com.yapp.muckpot.domains.user.enums
 
 enum class MuckPotStatus(
-    val krNm: String
+    val korNm: String
 ) {
     IN_PROGRESS("모집중"), DONE("모집마감")
 }


### PR DESCRIPTION
## 개요
- close #50 

## 작업사항
- 먹팟 상세조회 구현
- [x] 조건에 따른 참여자 목록 정렬 적용
 - 로그인 유저가 참여한 먹팟이라면 가장 상단에 위치한다.
- [x] 조직장 구분
- 조직장인 경우: writer: true
- 아닌 경우: 필드 없음.
- [x] 조회수 증가
- 상세 조회시 조회수 증가


## 변경로직
- 먹팟 글 리스트 조회랑 같은 응답 Dto 사용하려고 공통처리해서, 기존 먹팟 글 리스트 조회시 참여자 목록에 jobGroupMain 추가되었습니다.
- 프로필 조회 api 에서 Cookie를 다시 읽을 필요가 없을것 같아서 SecurityContextHolder에서 유저정보 가져오도록 변경하였습니다.
  -`/users/profile`
- 시간 관련 상수 위치 변경하였습니다.
- enum 한글 명 korNm 으로 통일하였습니다.