### PR TITLE
feat: 먹팟 글 상태변경 API 구현

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
@@ -8,6 +8,7 @@ import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateResponse
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotUpdateRequest
 import com.yapp.muckpot.domains.board.service.BoardService
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 import com.yapp.muckpot.swagger.MUCKPOT_FIND_ALL
 import com.yapp.muckpot.swagger.MUCKPOT_FIND_BY_ID
 import com.yapp.muckpot.swagger.MUCKPOT_JOIN_RESPONSE
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import javax.validation.Valid
 
@@ -163,6 +165,25 @@ class BoardController(
         @PathVariable boardId: Long
     ): ResponseEntity<ResponseDto> {
         boardService.deleteBoard(userId, boardId)
+        return ResponseEntityUtil.noContent()
+    }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 204,
+                message = "먹팟 글 상태변경 성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "먹팟 글 상태변경")
+    @PatchMapping("/v1/boards/{boardId}/status")
+    fun changeStatus(
+        @AuthenticationPrincipal userId: Long,
+        @PathVariable boardId: Long,
+        @RequestParam("status") status: MuckPotStatus
+    ): ResponseEntity<ResponseDto> {
+        boardService.changeStatus(userId, boardId, status)
         return ResponseEntityUtil.noContent()
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -14,6 +14,7 @@ import com.yapp.muckpot.domains.board.repository.BoardRepository
 import com.yapp.muckpot.domains.board.repository.ParticipantQuerydslRepository
 import com.yapp.muckpot.domains.board.repository.ParticipantRepository
 import com.yapp.muckpot.domains.user.controller.dto.UserResponse
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 import com.yapp.muckpot.domains.user.exception.UserErrorCode
 import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
 import com.yapp.muckpot.exception.MuckPotException
@@ -98,6 +99,18 @@ class BoardService(
             }
             participantRepository.deleteByBoard(board)
             boardRepository.delete(board)
+        } ?: run {
+            throw MuckPotException(BoardErrorCode.BOARD_NOT_FOUND)
+        }
+    }
+
+    @Transactional
+    fun changeStatus(userId: Long, boardId: Long, changeStatus: MuckPotStatus) {
+        boardRepository.findByIdOrNull(boardId)?.let { board ->
+            if (board.isNotMyBoard(userId)) {
+                throw MuckPotException(BoardErrorCode.BOARD_UNAUTHORIZED)
+            }
+            board.changeStatus(changeStatus)
         } ?: run {
             throw MuckPotException(BoardErrorCode.BOARD_NOT_FOUND)
         }

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -11,6 +11,7 @@ import com.yapp.muckpot.domains.board.repository.ParticipantRepository
 import com.yapp.muckpot.domains.user.controller.dto.UserResponse
 import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import com.yapp.muckpot.domains.user.enums.JobGroupMain
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus
 import com.yapp.muckpot.domains.user.repository.MuckPotUserRepository
 import com.yapp.muckpot.exception.MuckPotException
 import com.yapp.muckpot.fixture.Fixture
@@ -216,5 +217,15 @@ class BoardServiceTest @Autowired constructor(
         // then
         val findBoard = participantRepository.findByBoard(board)
         findBoard shouldHaveSize 0
+    }
+
+    "먹팟 상태변경 성공" {
+        // given
+        val boardId = boardRepository.save(Fixture.createBoard(user = user)).id!!
+        // when
+        boardService.changeStatus(userId, boardId, MuckPotStatus.DONE)
+        // then
+        val actual = boardRepository.findByIdOrNull(boardId)!!
+        actual.status shouldBe MuckPotStatus.DONE
     }
 })

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -9,6 +9,8 @@ import com.yapp.muckpot.common.MAX_APPLY_MIN
 import com.yapp.muckpot.common.enums.State
 import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import com.yapp.muckpot.domains.user.enums.MuckPotStatus
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus.DONE
+import com.yapp.muckpot.domains.user.enums.MuckPotStatus.IN_PROGRESS
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.Where
 import java.time.LocalDateTime
@@ -24,6 +26,7 @@ import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.Table
+
 @Entity
 @Table(name = "board")
 @Where(clause = "state = \'ACTIVE\'")
@@ -67,7 +70,7 @@ class Board(
 
     @Enumerated(value = EnumType.STRING)
     @Column(name = "status")
-    var status: MuckPotStatus = MuckPotStatus.IN_PROGRESS,
+    var status: MuckPotStatus = IN_PROGRESS,
 
     @Column(name = "min_age")
     var minAge: Int = AGE_MIN,
@@ -89,10 +92,10 @@ class Board(
     fun join(userAge: Int) {
         require(userAge in minAge..maxAge) { "참여 가능 나이가 아닙니다." }
         require(currentApply < maxApply) { "참여 모집이 마감되었습니다." }
-        require(status == MuckPotStatus.IN_PROGRESS) { "참여 모집이 마감되었습니다." }
+        require(status == IN_PROGRESS) { "참여 모집이 마감되었습니다." }
         this.currentApply++
         if (currentApply == maxApply) {
-            this.status = MuckPotStatus.DONE
+            this.status = DONE
         }
     }
 
@@ -101,7 +104,7 @@ class Board(
     }
 
     fun expired(): Boolean {
-        return (this.status == MuckPotStatus.IN_PROGRESS && this.meetingTime.isBefore(LocalDateTime.now()))
+        return (this.status == IN_PROGRESS && this.meetingTime.isBefore(LocalDateTime.now()))
     }
 
     fun getX(): Double {
@@ -114,5 +117,14 @@ class Board(
 
     fun isNotMyBoard(userId: Long): Boolean {
         return this.user.id != userId
+    }
+
+    fun changeStatus(changeStatus: MuckPotStatus) {
+        require(
+            (this.status == IN_PROGRESS && changeStatus == DONE) ||
+                ((this.status == DONE && changeStatus == IN_PROGRESS) && currentApply < maxApply)
+        ) { "변경 가능한 상태가 아닙니다." }
+
+        this.status = changeStatus
     }
 }

--- a/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
+++ b/muckpot-domain/src/test/kotlin/com/yapp/muckpot/domains/board/entity/BoardTest.kt
@@ -4,6 +4,7 @@ import com.yapp.muckpot.common.Location
 import com.yapp.muckpot.common.MAX_APPLY_MIN
 import com.yapp.muckpot.domains.user.entity.MuckPotUser
 import com.yapp.muckpot.domains.user.enums.MuckPotStatus
+import com.yapp.muckpot.fixture.Fixture
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -101,6 +102,47 @@ class BoardTest : FunSpec({
             shouldThrow<IllegalArgumentException> {
                 board.join(40)
             }.message shouldBe "참여 가능 나이가 아닙니다."
+        }
+
+        test("IN_PROGRESS 일 때는 DONE 으로만 변경할 수 있다.") {
+            val board = Fixture.createBoard(status = MuckPotStatus.IN_PROGRESS)
+
+            shouldThrow<IllegalArgumentException> {
+                board.changeStatus(MuckPotStatus.IN_PROGRESS)
+            }.message shouldBe "변경 가능한 상태가 아닙니다."
+        }
+
+        test("DONE 일 때는 IN_PROGRESS 으로만 변경할 수 있다.") {
+            val board = Fixture.createBoard(status = MuckPotStatus.DONE)
+
+            shouldThrow<IllegalArgumentException> {
+                board.changeStatus(MuckPotStatus.DONE)
+            }.message shouldBe "변경 가능한 상태가 아닙니다."
+        }
+
+        test("모집인원이 마감된 경우에는 IN_PROGRESS 로 변경할 수 없다.") {
+            val board = Fixture.createBoard(
+                status = MuckPotStatus.DONE,
+                currentApply = 3,
+                maxApply = 3
+            )
+            shouldThrow<IllegalArgumentException> {
+                board.changeStatus(MuckPotStatus.IN_PROGRESS)
+            }.message shouldBe "변경 가능한 상태가 아닙니다."
+        }
+
+        test("IN_PROGRESS -> DONE 변경 성공") {
+            val board = Fixture.createBoard()
+            board.changeStatus(MuckPotStatus.DONE)
+
+            board.status shouldBe MuckPotStatus.DONE
+        }
+
+        test("DONE -> IN_PROGRESS 변경 성공") {
+            val board = Fixture.createBoard(status = MuckPotStatus.DONE)
+            board.changeStatus(MuckPotStatus.IN_PROGRESS)
+
+            board.status shouldBe MuckPotStatus.IN_PROGRESS
         }
     }
 })


### PR DESCRIPTION
## 개요
- close #62 

## 작업사항
- 먹팟 글 상태변경 API 구현
- [x] ktlintFormat 적용
- [x] 자신의 글만 변경할 수 있다.
- [x] 모집 종료 및, 다시 모집할 수 있다.
- 모집 종료는 IN_PROGRESS 상태에서만 가능
- 다시 모집은 DONE 상태이면서, currentApply < maxApply 상태에서만 가능
