### PR TITLE
refactor: 65 로그인 유지하기 만료시간 지정

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtConstant.kt
@@ -1,7 +1,15 @@
 package com.yapp.muckpot.common
 
+const val USER_CLAIM = "user"
+const val USER_EMAIL_CLAIM = "email"
+
 const val LOGIN_URL = "/api/v1/users/login"
 const val SIGN_UP_URL = "/api/v1/users"
 const val EMAIL_REQUEST = "/api/v1/emails/request"
 const val EMAIL_VERIFY = "/api/v1/emails/verify"
 const val USER_PROFILE_URL = "/v1/users/profile"
+
+const val ACCESS_TOKEN_BASIC_SECONDS = 3600L
+const val ACCESS_TOKEN_KEEP_SECONDS = 3600 * 24L
+const val REFRESH_TOKEN_BASIC_SECONDS = 3600 * 24 * 7L
+const val REFRESH_TOKEN_KEEP_SECONDS = 3600 * 24 * 30L

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtCookieUtil.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/JwtCookieUtil.kt
@@ -33,11 +33,12 @@ object JwtCookieUtil {
     /**
      * 현재 응답에 ACCESS_TOKEN 쿠키 추가.
      */
-    fun addAccessTokenCookie(accessToken: String) {
+    fun addAccessTokenCookie(accessToken: String, expiredSeconds: Int) {
         currentResponse.addCookie(
             Cookie(ACCESS_TOKEN, accessToken).apply {
                 path = "/"
                 isHttpOnly = true
+                maxAge = expiredSeconds
             }
         )
     }
@@ -45,11 +46,12 @@ object JwtCookieUtil {
     /**
      * 현재 응답에 REFRESH_TOKEN 쿠키 추가.
      */
-    fun addRefreshTokenCookie(jwtToken: String) {
+    fun addRefreshTokenCookie(jwtToken: String, expiredSeconds: Int) {
         currentResponse.addCookie(
             Cookie(REFRESH_TOKEN, jwtToken).apply {
                 path = "/"
                 isHttpOnly = true
+                maxAge = expiredSeconds
             }
         )
     }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/ValidationMessageConstant.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/common/ValidationMessageConstant.kt
@@ -1,6 +1,6 @@
 package com.yapp.muckpot.common
 
-const val MAX_APPLY_MIN_INVALID = "최대 인원은 {value}명 이상 가능합니다."
+const val MAX_APPLY_MIN_INVALID = "참여 인원은 {value}명 이상 가능합니다."
 const val TITLE_MAX_INVALID = "제목은 {max}(자)를 넘을 수 없습니다."
 const val CONTENT_MAX_INVALID = "내용은 {max}(자)를 넘을 수 없습니다."
 const val LINK_MAX_INVALID = "링크는 {max}(자)를 넘을 수 없습니다."

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotCreateRequest.kt
@@ -33,7 +33,7 @@ data class MuckpotCreateRequest(
     @field:ApiModelProperty(notes = "만날 시간", required = true, example = "13:00")
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
-    @field:ApiModelProperty(notes = "최대 인원", required = true, example = "5")
+    @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
     @field:Min(2, message = MAX_APPLY_MIN_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/dto/MuckpotUpdateRequest.kt
@@ -34,7 +34,7 @@ data class MuckpotUpdateRequest(
     @field:ApiModelProperty(notes = "만날 시간", required = true, example = "13:00")
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = HHmm)
     val meetingTime: LocalTime,
-    @field:ApiModelProperty(notes = "최대 인원", required = true, example = "5")
+    @field:ApiModelProperty(notes = "최대 참여 인원", required = true, example = "5")
     @field:Min(2, message = MAX_APPLY_MIN_INVALID)
     val maxApply: Int = 2,
     @field:ApiModelProperty(notes = "최소 나이", required = false, example = "20")

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/UserService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/UserService.kt
@@ -35,11 +35,14 @@ class UserService(
                 throw MuckPotException(UserErrorCode.LOGIN_FAIL)
             }
             val response = UserResponse.of(it)
-            val accessToken = jwtService.generateAccessToken(response, jwtService.getAccessTokenSeconds(request.keep))
-            val refreshToken = jwtService.generateRefreshToken(request.email, jwtService.getRefreshTokenSeconds(request.keep))
-            redisService.setDataExpireWithNewest(request.email, refreshToken, jwtService.getRefreshTokenSeconds(request.keep))
-            JwtCookieUtil.addAccessTokenCookie(accessToken)
-            JwtCookieUtil.addRefreshTokenCookie(refreshToken)
+            val accessTokenSeconds = jwtService.getAccessTokenSeconds(request.keep)
+            val refreshTokenSeconds = jwtService.getRefreshTokenSeconds(request.keep)
+            val accessToken = jwtService.generateAccessToken(response, accessTokenSeconds)
+            val refreshToken = jwtService.generateRefreshToken(request.email, refreshTokenSeconds)
+
+            redisService.setDataExpireWithNewest(request.email, refreshToken, refreshTokenSeconds)
+            JwtCookieUtil.addAccessTokenCookie(accessToken, accessTokenSeconds.toInt())
+            JwtCookieUtil.addRefreshTokenCookie(refreshToken, refreshTokenSeconds.toInt())
             return response
         } ?: run {
             throw MuckPotException(UserErrorCode.LOGIN_FAIL)

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/UserService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/user/service/UserService.kt
@@ -35,9 +35,9 @@ class UserService(
                 throw MuckPotException(UserErrorCode.LOGIN_FAIL)
             }
             val response = UserResponse.of(it)
-            val accessToken = jwtService.generateAccessToken(response, request.keep)
-            val refreshToken = jwtService.generateRefreshToken(request.email, request.keep)
-            redisService.saveRefreshToken(request.email, refreshToken)
+            val accessToken = jwtService.generateAccessToken(response, jwtService.getAccessTokenSeconds(request.keep))
+            val refreshToken = jwtService.generateRefreshToken(request.email, jwtService.getRefreshTokenSeconds(request.keep))
+            redisService.setDataExpireWithNewest(request.email, refreshToken, jwtService.getRefreshTokenSeconds(request.keep))
             JwtCookieUtil.addAccessTokenCookie(accessToken)
             JwtCookieUtil.addRefreshTokenCookie(refreshToken)
             return response

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/constants/TimeConstant.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/common/constants/TimeConstant.kt
@@ -7,6 +7,7 @@ const val TOMORROW_KR = "내일"
 const val HOUR_IN_MINUTES = 60
 const val MINUTES_IN_ONE_DAY = 1440
 const val MINUTES_IN_TWO_DAY = 2880
+const val MS = 1000
 
 const val N_MINUTES_AGO = "%d분 전"
 const val N_HOURS_AGO = "%d시간 전"

--- a/muckpot-infra/src/main/kotlin/com/yapp/muckpot/redis/RedisService.kt
+++ b/muckpot-infra/src/main/kotlin/com/yapp/muckpot/redis/RedisService.kt
@@ -14,16 +14,13 @@ class RedisService(private val redisTemplate: RedisTemplate<String, Any>) {
         return operations.get("test") as String
     }
 
-    fun saveRefreshToken(email: String, refreshToken: String) {
-        redisTemplate.opsForValue().set(email, refreshToken)
-    }
-
     fun setDataExpireWithNewest(key: String, value: String, duration: Long) {
         if (redisTemplate.hasKey(key)) {
             redisTemplate.delete(key)
         }
         redisTemplate.opsForValue().set(key, value, Duration.ofSeconds(duration))
     }
+
     fun deleteData(key: String) {
         redisTemplate.delete(key)
     }


### PR DESCRIPTION
## 개요
- close #65

## 작업사항
- 기존 만료시간이 없는 토큰의 경우 보안상 취약하여, 로그인 유지하기 기능에도 만료시간을 지정하였습니다.

## 변경로직
- as-is
  - 로그인 유지하기 선택: 토큰 만료기한 없음
  - 로그인 유지하기 미선택: 한시간, 일주일
- to-be
  - 로그인 유지하기 선택: Access 1일, Refresh 30일
    - [카카오 로그인 API 참조하여 30일](https://cs.kakao.com/helps?articleId=1073192624&service=52&category=166&device=423&locale=ko)
  - 로그인 유지하기 미선택: 한시간, 일주일