### PR TITLE
feat : 67 먹팟 참가 신청 취소 api 구현

### DIFF
--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
@@ -201,7 +201,7 @@ class BoardController(
         @AuthenticationPrincipal userId: Long,
         @PathVariable boardId: Long
     ): ResponseEntity<ResponseDto> {
-        boardService.deleteParticipant(userId, boardId)
+        boardService.cancelJoin(userId, boardId)
         return ResponseEntityUtil.noContent()
     }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/controller/BoardController.kt
@@ -186,4 +186,22 @@ class BoardController(
         boardService.changeStatus(userId, boardId, status)
         return ResponseEntityUtil.noContent()
     }
+
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                code = 204,
+                message = "먹팟 참가 신청 취소 성공"
+            )
+        ]
+    )
+    @ApiOperation(value = "먹팟 참가 신청 취소")
+    @DeleteMapping("/v1/boards/{boardId}/join")
+    fun deleteParticipant(
+        @AuthenticationPrincipal userId: Long,
+        @PathVariable boardId: Long
+    ): ResponseEntity<ResponseDto> {
+        boardService.deleteParticipant(userId, boardId)
+        return ResponseEntityUtil.noContent()
+    }
 }

--- a/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
+++ b/muckpot-api/src/main/kotlin/com/yapp/muckpot/domains/board/service/BoardService.kt
@@ -118,7 +118,7 @@ class BoardService(
     }
 
     @Transactional
-    fun deleteParticipant(userId: Long, boardId: Long) {
+    fun cancelJoin(userId: Long, boardId: Long) {
         // TODO 먹팟 참가 신청 취소 시 참여 인원에게 메일 전송 기획 논의
         boardRepository.findByIdOrNull(boardId)?.let { board ->
             val user = userRepository.findByIdOrNull(userId)

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -234,9 +234,8 @@ class BoardServiceTest @Autowired constructor(
 
     "먹팟 참가 신청 취소 성공" {
         // given
-        val boardUser = userRepository.save(Fixture.createUser())
         val applyUser = userRepository.save(Fixture.createUser())
-        val board = boardRepository.save(Fixture.createBoard(user = boardUser))
+        val board = boardRepository.save(Fixture.createBoard(user = user))
         participantRepository.save(Participant(applyUser, board))
         // when
         boardService.deleteParticipant(applyUser.id!!, board.id!!)
@@ -248,9 +247,8 @@ class BoardServiceTest @Autowired constructor(
 
     "기존 참가 신청 내역 없으면 참가 신청 취소 불가" {
         // given
-        val boardUser = userRepository.save(Fixture.createUser())
         val applyUser = userRepository.save(Fixture.createUser())
-        val board = boardRepository.save(Fixture.createBoard(user = boardUser))
+        val board = boardRepository.save(Fixture.createBoard(user = user))
         // when & then
         shouldThrow<MuckPotException> {
             boardService.deleteParticipant(applyUser.id!!, board.id!!)
@@ -259,12 +257,11 @@ class BoardServiceTest @Autowired constructor(
 
     "먹팟 글 작성자는 참가 신청 취소할 수 없다." {
         // given
-        val boardUser = userRepository.save(Fixture.createUser())
-        val board = boardRepository.save(Fixture.createBoard(user = boardUser))
-        participantRepository.save(Participant(boardUser, board))
+        val board = boardRepository.save(Fixture.createBoard(user = user))
+        participantRepository.save(Participant(user, board))
         // when & then
         shouldThrow<MuckPotException> {
-            boardService.deleteParticipant(boardUser.id!!, board.id!!)
+            boardService.deleteParticipant(user.id!!, board.id!!)
         }.errorCode shouldBe ParticipantErrorCode.WRITER_MUST_JOIN
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -5,7 +5,9 @@ import com.yapp.muckpot.common.enums.Gender
 import com.yapp.muckpot.common.redisson.ConcurrencyHelper
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotCreateRequest
 import com.yapp.muckpot.domains.board.controller.dto.MuckpotUpdateRequest
+import com.yapp.muckpot.domains.board.entity.Participant
 import com.yapp.muckpot.domains.board.exception.BoardErrorCode
+import com.yapp.muckpot.domains.board.exception.ParticipantErrorCode
 import com.yapp.muckpot.domains.board.repository.BoardRepository
 import com.yapp.muckpot.domains.board.repository.ParticipantRepository
 import com.yapp.muckpot.domains.user.controller.dto.UserResponse
@@ -25,6 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.*
 import java.util.concurrent.atomic.AtomicLong
 
 @SpringBootTest
@@ -162,7 +165,7 @@ class BoardServiceTest @Autowired constructor(
         val boardId = boardService.saveBoard(userId, createRequest)!!
         shouldThrow<MuckPotException> {
             boardService.joinBoard(userId, boardId)
-        }.errorCode shouldBe BoardErrorCode.ALREADY_JOIN
+        }.errorCode shouldBe ParticipantErrorCode.ALREADY_JOIN
     }
 
     "먹팟 참가 동시성 테스트" {
@@ -227,5 +230,41 @@ class BoardServiceTest @Autowired constructor(
         // then
         val actual = boardRepository.findByIdOrNull(boardId)!!
         actual.status shouldBe MuckPotStatus.DONE
+    }
+
+    "먹팟 참가 신청 취소 성공" {
+        // given
+        val boardUser = userRepository.save(Fixture.createUser())
+        val applyUser = userRepository.save(Fixture.createUser())
+        val board = boardRepository.save(Fixture.createBoard(user = boardUser))
+        participantRepository.save(Participant(applyUser, board))
+        // when
+        boardService.deleteParticipant(applyUser.id!!, board.id!!)
+        // then
+        val findParticipant = participantRepository.findByUserAndBoard(applyUser, board)
+        findParticipant shouldBe null
+        board.currentApply shouldBe 0
+    }
+
+    "기존 참가 신청 내역 없으면 참가 신청 취소 불가" {
+        // given
+        val boardUser = userRepository.save(Fixture.createUser())
+        val applyUser = userRepository.save(Fixture.createUser())
+        val board = boardRepository.save(Fixture.createBoard(user = boardUser))
+        // when & then
+        shouldThrow<MuckPotException> {
+            boardService.deleteParticipant(applyUser.id!!, board.id!!)
+        }.errorCode shouldBe ParticipantErrorCode.PARTICIPANT_NOT_FOUND
+    }
+
+    "먹팟 글 작성자는 참가 신청 취소할 수 없다." {
+        // given
+        val boardUser = userRepository.save(Fixture.createUser())
+        val board = boardRepository.save(Fixture.createBoard(user = boardUser))
+        participantRepository.save(Participant(boardUser, board))
+        // when & then
+        shouldThrow<MuckPotException> {
+            boardService.deleteParticipant(boardUser.id!!, board.id!!)
+        }.errorCode shouldBe ParticipantErrorCode.WRITER_MUST_JOIN
     }
 })

--- a/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
+++ b/muckpot-api/src/test/kotlin/com/yapp/muckpot/domains/board/service/BoardServiceTest.kt
@@ -238,7 +238,7 @@ class BoardServiceTest @Autowired constructor(
         val board = boardRepository.save(Fixture.createBoard(user = user))
         participantRepository.save(Participant(applyUser, board))
         // when
-        boardService.deleteParticipant(applyUser.id!!, board.id!!)
+        boardService.cancelJoin(applyUser.id!!, board.id!!)
         // then
         val findParticipant = participantRepository.findByUserAndBoard(applyUser, board)
         findParticipant shouldBe null
@@ -251,7 +251,7 @@ class BoardServiceTest @Autowired constructor(
         val board = boardRepository.save(Fixture.createBoard(user = user))
         // when & then
         shouldThrow<MuckPotException> {
-            boardService.deleteParticipant(applyUser.id!!, board.id!!)
+            boardService.cancelJoin(applyUser.id!!, board.id!!)
         }.errorCode shouldBe ParticipantErrorCode.PARTICIPANT_NOT_FOUND
     }
 
@@ -261,7 +261,7 @@ class BoardServiceTest @Autowired constructor(
         participantRepository.save(Participant(user, board))
         // when & then
         shouldThrow<MuckPotException> {
-            boardService.deleteParticipant(user.id!!, board.id!!)
+            boardService.cancelJoin(user.id!!, board.id!!)
         }.errorCode shouldBe ParticipantErrorCode.WRITER_MUST_JOIN
     }
 })

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/entity/Board.kt
@@ -127,4 +127,8 @@ class Board(
 
         this.status = changeStatus
     }
+
+    fun cancelJoin() {
+        this.currentApply--
+    }
 }

--- a/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/exception/ParticipantErrorCode.kt
+++ b/muckpot-domain/src/main/kotlin/com/yapp/muckpot/domains/board/exception/ParticipantErrorCode.kt
@@ -4,13 +4,13 @@ import com.yapp.muckpot.common.BaseErrorCode
 import com.yapp.muckpot.common.ResponseDto
 import com.yapp.muckpot.common.enums.StatusCode
 
-enum class BoardErrorCode(
+enum class ParticipantErrorCode(
     private val status: Int,
     private val reason: String
 ) : BaseErrorCode {
-    BOARD_NOT_FOUND(StatusCode.BAD_REQUEST.code, "먹팟 정보를 찾을 수 없습니다."),
-    MAX_APPLY_UPDATE_FAIL(StatusCode.BAD_REQUEST.code, "현재 참여인원 이상으로만 설정 가능합니다."),
-    BOARD_UNAUTHORIZED(StatusCode.UNAUTHORIZED.code, "내가 작성한 글에만 접근할 수 있습니다.");
+    ALREADY_JOIN(StatusCode.BAD_REQUEST.code, "이미 참여한 유저입니다."),
+    PARTICIPANT_NOT_FOUND(StatusCode.BAD_REQUEST.code, "참여 정보를 찾을 수 없습니다."),
+    WRITER_MUST_JOIN(StatusCode.BAD_REQUEST.code, "글 작성자는 참가 신청 취소 불가합니다.");
 
     override fun toResponseDto(): ResponseDto {
         return ResponseDto(this.status, this.reason, null)


### PR DESCRIPTION
## 개요
- close #67 

## 작업사항
- 먹팟 참가 신청 취소 api 구현
 participant table soft delete
 muckpot_user.current_apply update
- validation 처리
- 테스트 코드 작성

## 변경로직
- ParticipantErrorCode enum 생성